### PR TITLE
build(ci): drop macos-15-intel from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macOS — arm64 (M-series) and amd64 (Intel) on Sequoia.
-          # macos-26 is GitHub's Apple-Silicon-only runner; macos-15-intel
-          # replaced the retired macos-13 image and stays available
-          # through 2027 while Apple's Intel transition wraps up.
+          # macOS — Apple Silicon only on Sequoia (macos-26).
+          # x86_64 macOS isn't in the matrix because release.yml
+          # cross-compiles the x86_64 macOS binary from macos-26
+          # since commit e3a4d28 (cargo-packager's create-dmg step
+          # bombed on the Intel image with no recoverable
+          # diagnostic). Testing natively on macos-15-intel while
+          # shipping a cross-compiled binary would test one path
+          # and ship another — keeping CI aligned with what release
+          # actually produces. macos-15-intel can return when
+          # native Intel builds do (unlikely, given the Apple
+          # transition timeline).
           - runner: macos-26
             arch: arm64
-          - runner: macos-15-intel
-            arch: amd64
           # Windows — x64 + arm64. windows-11-arm landed in 2025 and
           # gives us a native runner; no Prism cross-compile dance.
           - runner: windows-latest


### PR DESCRIPTION
## Summary
- Removes the `macos-15-intel` matrix entry from `ci.yml`.
- Updates the inline matrix comment to link the decision back to e3a4d28 (release.yml's earlier switch to cross-compiling x86_64 macOS from `macos-26`).

## Why
release.yml stopped producing native x86_64 macOS binaries in e3a4d28 — cargo-packager's `create-dmg` step bombed on the macos-15-intel image with no recoverable diagnostic, and the fix was cross-compiling x86_64 macOS from macos-26 alongside the native arm64 build. CI was never updated to match: it kept testing natively on macos-15-intel while release shipped the cross-compiled output.

That's the worst of both worlds — we test one path and ship another with no overlap. The native-x86_64 CI run only verifies "the code that would have been built natively works," not "the cross-compiled output we actually distribute works."

This commit takes the consistent stance: both CI and release are Apple-Silicon-only on macOS.

## Why this is a separate PR
This commit was originally part of #38's audit branch but landed on the branch ~32 minutes after #38 was merged, so the squash-merge didn't pick it up. Cherry-picked clean onto a fresh branch off `main` to avoid the 28-commit re-PR confusion that'd result from re-opening from the original branch (whose history no longer shares ancestry with main's squashed equivalent).

## Test plan
- [x] `actionlint` clean on the workflow change
- [ ] CI matrix on this PR has 5 entries instead of 6 (no `macos-15-intel`), all green

## Risk
Low. No x86_64-specific code in the tree (no SIMD, no arch-gated cfg, no x86-only deps that aren't well-tested upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)