### PR TITLE
docs(changelog): cut v0.13.0 from [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ final stable entry at tag time.
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-24
+
 ### Fixed
 
 - **Windows-arm winget launches no longer hit the cleanup-time
@@ -23,17 +25,25 @@ final stable entry at tag time.
   exposed a deeper panic in `AsyncApp::update_entity` firing during
   cleanup of the gpui state we set up before the failed window
   open (`gpui_component::init`, settings-bus subscribe, theme
-  global). The `[Unreleased]` build adds a Direct3D adapter probe
-  via inline `D3D11CreateDevice` FFI before any gpui state exists:
-  if the OS can't hand back a graphics adapter, Baudrun pops the
-  same "failed to start" dialog and exits cleanly with code `0`
-  — zero gpui state to clean up means zero cleanup-time panic.
-  The winget validator's 10-second launch test accepts either a
-  clean exit or a still-running process, so both real-user
-  broken-GPU machines and the validator's headless sandbox now
-  behave the same way. Unblocks re-adding arm64 to the winget
-  manifest after the v0.12.4 submission shipped x64-only
+  global). v0.13.0 adds a Direct3D adapter probe via inline
+  `D3D11CreateDevice` FFI before any gpui state exists: if the OS
+  can't hand back a graphics adapter, Baudrun pops the same
+  "failed to start" dialog and exits cleanly with code `0` —
+  zero gpui state to clean up means zero cleanup-time panic. The
+  winget validator's 10-second launch test accepts either a clean
+  exit or a still-running process, so both real-user broken-GPU
+  machines and the validator's headless sandbox now behave the
+  same way. Unblocks re-adding arm64 to the winget manifest after
+  the v0.12.4 submission shipped x64-only
   ([microsoft/winget-pkgs#377461](https://github.com/microsoft/winget-pkgs/pull/377461)).
+
+### Changed
+
+- **gpui + gpui_platform bumped to upstream Zed rev `13e7c11`.**
+  Carries forward four weeks of Zed-side improvements to the
+  windowing + event-loop paths since the v0.12-line pin
+  (`0042fb5`). No public API changes on our side; the bump is
+  transparent on macOS, Windows, and Linux desktops.
 
 ## [0.12.4] — 2026-05-21
 


### PR DESCRIPTION
## Summary
Pre-tag cleanup: moves the DXGI probe entry from `[Unreleased]` into a versioned `[0.13.0]` section dated today, and adds a `[Changed]` entry for the gpui upstream-rev bump that landed in #36.

## What's in v0.13.0

Three PRs merged today (in order):
- **#38** — audit cleanup + DXGI probe for Windows-arm winget (squash of 27 commits)
- **#39** — drop macos-15-intel from the CI matrix
- **#36** — bump gpui to upstream rev `13e7c11` (subsumed #37's gpui_platform PR since both deps share the Zed git URL and Cargo unified them on the rebase)

Plus dev-tool / internal-refactor changes (file splits, cargo-deny, workflow_dispatch, fmt + scripts CI gates, Tauri-residue deletion) that stay out of CHANGELOG per CONTRIBUTING.md — `git log` carries the detail.

## After this merges
1. Tag `v0.13.0-beta.1` → release.yml fires pre-release flow (NSIS + .zip ship, no MSI per the existing `contains('-')` gate)
2. Beta-test the gpui bump on real hardware
3. Tag `v0.13.0` → full MSI build, ships to Releases
4. `wingetcreate update packetThrower.Baudrun --version 0.13.0 --urls $X64,$ARM64 --submit` → arm64 back on winget after the v0.12.4 omission

## Test plan
- [x] CHANGELOG syntax matches the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) shape of prior entries
- [x] Release date set to today (2026-05-24), the day all v0.13.0 content landed on main
- [x] All required CI checks expected green (no source changes; docs-only commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)