### PR TITLE
build(ci): automate winget submissions via after_release.yml

### DIFF
--- a/.github/workflows/after_release.yml
+++ b/.github/workflows/after_release.yml
@@ -1,0 +1,103 @@
+name: After Release
+
+# Fires after a GitHub Release has been published by release.yml's `release`
+# job (which uses softprops/action-gh-release on tag-push). Separate workflow
+# from release.yml so the release job stays focused on building + uploading
+# artifacts; post-release publishing — currently the winget submission, more
+# in the future — lives here.
+#
+# The workflow_dispatch trigger lets us manually re-run a winget submission
+# if the release-event-triggered run flakes (rare but documented in the
+# winget-pkgs validator history).
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: >-
+          Stable tag to submit (e.g. `v0.13.0`, no leading "v" optional —
+          the winget-releaser action accepts both). Lets us re-fire the
+          submission if the release-event-triggered run didn't catch
+          (race condition during a slow Release publish, transient GitHub
+          API failure during the action's fork-PR step, etc.).
+        required: true
+        type: string
+
+# Per-job permissions ceiling. The publish job only reads this repo; the
+# upstream PR against microsoft/winget-pkgs is opened via the WINGET_TOKEN
+# PAT (under the maintainer's account), not the workflow's GITHUB_TOKEN.
+permissions:
+  contents: read
+
+jobs:
+  publish_winget:
+    name: Submit to winget-pkgs
+    runs-on: windows-latest
+    # Guard against forks accidentally running the publish path. The
+    # WINGET_TOKEN secret won't be set on a fork anyway, but failing fast
+    # with a clean skip is friendlier than a mid-action 401.
+    #
+    # Skip on pre-releases — the manifest schema's `ProductVersion` field
+    # rejects alphanumeric segments (`-beta.N`), MSI builds are skipped
+    # for pre-release tags by release.yml's existing `contains('-')` gate
+    # anyway, and winget itself has no pre-release channel. Stable only.
+    if: >-
+      github.repository_owner == 'packetThrower' &&
+      (
+        (github.event_name == 'release' && !github.event.release.prerelease) ||
+        (github.event_name == 'workflow_dispatch' && !contains(inputs.tag_name, '-'))
+      )
+    steps:
+      # Pre-step before the action runs: sync the maintainer's fork of
+      # microsoft/winget-pkgs against upstream master. wingetcreate (which
+      # the winget-releaser action wraps) opens the PR from a branch on
+      # that fork; if the fork has drifted behind upstream, the PR open
+      # fails with a merge-conflict or non-fast-forward error. The
+      # /merge-upstream endpoint does a GitHub-side fast-forward when
+      # possible, no-ops when already current, and fails benignly when
+      # the fork doesn't exist (logged + ignored — the action will
+      # surface a useful error in that case).
+      - name: Sync fork against upstream
+        shell: pwsh
+        run: |
+          $headers = @{
+            "Authorization" = "Bearer $env:WINGET_TOKEN"
+            "Accept" = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $body = @{ branch = "master" } | ConvertTo-Json
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY_OWNER/winget-pkgs/merge-upstream"
+          try {
+            Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -Body $body -ContentType "application/json"
+            Write-Host "Synced winget-pkgs fork against upstream master"
+          } catch {
+            Write-Host "Fork sync skipped (already up to date or fork missing): $_"
+            Write-Host "Continuing — the winget-releaser action will surface a real error if the fork is genuinely unreachable"
+          }
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+
+      # Open the winget-pkgs PR. SHA-pinned for the same supply-chain
+      # reason ci.yml pins its third-party actions: a mutable tag could
+      # be repointed at malicious code by a token compromise on the
+      # action's repo. `# v2` is what Dependabot reads + bumps on a real
+      # release.
+      #
+      # `identifier`: the PackageIdentifier our manifest declares
+      # (`packaging/windows/winget/packetThrower.Baudrun.installer.yaml.template`).
+      # `release-tag`: drawn from the triggering Release on the auto-
+      # fire path, from the dispatch input on the manual path.
+      # `max-versions-to-keep`: bounds the per-version directories in
+      # `microsoft/winget-pkgs/manifests/p/packetThrower/Baudrun/` so
+      # the tree doesn't accumulate every historical version. 5 gives
+      # users 4-5 releases of "downgrade target" surface before old
+      # versions roll off.
+      - name: Open winget-pkgs PR
+        uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f # v2
+        with:
+          identifier: packetThrower.Baudrun
+          release-tag: ${{ github.event.release.tag_name || inputs.tag_name }}
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/packaging/windows/winget/README.md
+++ b/packaging/windows/winget/README.md
@@ -18,11 +18,41 @@ to hand-write the YAML each release.
 | `packetThrower.Baudrun.installer.yaml.template` | Installer manifest. Substitute `${VERSION}`, `${RELEASE_DATE}`, `${SHA256_AMD64_MSI}`, `${SHA256_ARM64_MSI}`, `${PRODUCT_CODE_AMD64}`, `${PRODUCT_CODE_ARM64}`. |
 | `rendered/<version>/` | Archived copy of the YAMLs submitted upstream for each version. Mirrors what's at `manifests/p/packetThrower/Baudrun/<version>/` in `microsoft/winget-pkgs`. |
 
-## The submission, via wingetcreate (preferred)
+## The submission, automated via CI (preferred)
 
-`wingetcreate` is Microsoft's CLI for the winget-pkgs repo. It
-forks the upstream repo, commits the rendered manifests, and
-opens the PR for us.
+Stable tags fire `.github/workflows/after_release.yml::publish_winget`,
+which submits the winget-pkgs PR for us:
+
+  1. release.yml publishes the GitHub Release (stable tag only —
+     pre-release tags skip the MSI build and the winget submission).
+  2. The Release-published event fires `after_release.yml`.
+  3. The `publish_winget` job syncs the maintainer's
+     `packetThrower/winget-pkgs` fork against upstream master, then
+     runs `vedantmgoyal9/winget-releaser` to render the templates,
+     commit them under `manifests/p/packetThrower/Baudrun/<version>/`
+     on the fork, and open the PR against `microsoft/winget-pkgs`.
+  4. The winget-pkgs validator runs on the PR; on success a
+     moderator merges it.
+
+The flow is hands-off after the tag push. If the release-event
+trigger doesn't fire (rare GitHub Actions slow-publish race), use
+the `workflow_dispatch` trigger from the Actions UI with the tag
+name to re-run just the winget submission.
+
+**One-time setup** (already done as of v0.13.0):
+
+  * Personal access token (fine-grained) with **Contents: read +
+    write** and **Pull requests: read + write** on the maintainer's
+    `winget-pkgs` fork, stored as the `WINGET_TOKEN` repo secret.
+  * The fork at `packetThrower/winget-pkgs` exists and is current
+    enough for GitHub's `/merge-upstream` endpoint to fast-forward
+    against upstream master.
+
+## The submission, manually via wingetcreate
+
+Fallback path if the automation is offline or for a non-release
+emergency submission. `wingetcreate` is Microsoft's CLI for the
+winget-pkgs repo:
 
 ```powershell
 # Windows host. winget install Microsoft.WingetCreate (one-time).
@@ -48,7 +78,7 @@ wingetcreate update packetThrower.Baudrun `
 The `--submit` flag opens the PR for you. Without it, the YAMLs
 land in a temp directory for review.
 
-## The submission, manually
+## The submission, manually via in-repo render
 
 Targets the `winget-pkgs` fork's `manifests/p/packetThrower/Baudrun/<version>/` layout.
 


### PR DESCRIPTION
## Summary
Adds the workflow that submits a winget-pkgs PR on every stable release.

## Flow
1. Tag stable (`vX.Y.Z`, no hyphen).
2. `release.yml` builds artifacts including the per-arch `.msi`, then its `release` job publishes the GitHub Release via `softprops/action-gh-release`.
3. The Release-published event fires `after_release.yml::publish_winget`.
4. Job syncs the maintainer's `packetThrower/winget-pkgs` fork against upstream via `/merge-upstream`, then runs `winget-releaser` which renders the templates, commits under `manifests/p/packetThrower/Baudrun/<version>/` on the fork, opens the PR.
5. winget-pkgs validator runs on the PR; moderator merges.

Hands-off after the tag push.

## Skip conditions
- **Pre-release tags**: `if: !github.event.release.prerelease` (or `!contains(inputs.tag_name, '-')` on the dispatch path). Pre-releases already skip MSI in `release.yml`, so there's no MSI to submit; winget itself has no pre-release channel.
- **Forks**: `if: github.repository_owner == 'packetThrower'`. The `WINGET_TOKEN` secret isn't set on a fork anyway, but fail-fast is friendlier than a mid-action 401.

## Manual escape hatch
`workflow_dispatch` input `tag_name` lets us re-fire if the release-event trigger races against a slow Release publish or hits a GitHub API blip on the fork-PR step. Same flow, just manually re-entered tag.

## Setup (done out-of-band)
- Fine-grained PAT on the maintainer's `packetThrower/winget-pkgs` fork with `Contents: read+write` + `Pull requests: read+write`, stored as repo secret `WINGET_TOKEN`.

## Documentation
`packaging/windows/winget/README.md` gets a new "automated via CI" section. The existing `wingetcreate` manual flow stays as the emergency-override path; the in-repo render flow stays as reference. No content lost.

## Test plan
- [x] `actionlint` clean on the new workflow
- [x] `winget-releaser` SHA pin (`19e706d4c9121098010096f9c495a70a7518b30f`, `# v2`)
- [ ] First live run on v0.13.0's stable tag — if it fails, capture the actual error and iterate (likely candidates: fork sync auth, missing fork, manifest schema drift)

## Risk
- **Low** for the workflow shape — `winget-releaser` is well-established.
- **Medium** for first-run integration — never been exercised on this repo before. Fallback path stays available via manual `wingetcreate` if first-run fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)