### PR TITLE
docs(nav): add "← packetThrower" back-link pill to the docs header

### DIFF
--- a/docs-next/src/components/SocialIcons.astro
+++ b/docs-next/src/components/SocialIcons.astro
@@ -1,20 +1,32 @@
 ---
-// Override of Starlight's SocialIcons component. Renders a "Docs"
-// quick-access pill on the left, then defers to Starlight's default
-// rendering (the GitHub icon, etc.) for the rest. Wraps rather than
-// re-implements so future Starlight versions that change the social-
-// icon pipeline still work — we only own the `.bd-docs-link` extra.
+// Override of Starlight's SocialIcons component. Renders two
+// quick-access pills on the left — a "← packetThrower" back-link
+// to the parent landing page, then a "Docs" pill to /install/ —
+// then defers to Starlight's default rendering (the GitHub icon,
+// etc.) for the rest. Wraps rather than re-implements so future
+// Starlight versions that change the social-icon pipeline still
+// work — we only own the `.bd-nav-pill` extras.
+//
+// The back-link is an absolute URL on purpose: Astro's configured
+// `base` is `/Baudrun/`, so a relative `/` would resolve to
+// `/Baudrun/` (this site's own root). The absolute form skips the
+// base prefix and reaches the actual parent at
+// https://packetthrower.github.io/.
 import Default from '@astrojs/starlight/components/SocialIcons.astro';
 ---
 
-<a class="bd-docs-link sl-flex" href="/Baudrun/install/">
+<a class="bd-nav-pill sl-flex" href="https://packetthrower.github.io/">
+	<span aria-hidden="true">←</span> packetThrower
+</a>
+
+<a class="bd-nav-pill sl-flex" href="/Baudrun/install/">
 	Docs
 </a>
 
 <Default {...Astro.props}><slot /></Default>
 
 <style>
-	.bd-docs-link {
+	.bd-nav-pill {
 		align-items: center;
 		gap: 0.4em;
 		padding: 0.35em 0.85em;
@@ -28,7 +40,7 @@ import Default from '@astrojs/starlight/components/SocialIcons.astro';
 			color 140ms ease,
 			box-shadow 140ms ease;
 	}
-	.bd-docs-link:hover {
+	.bd-nav-pill:hover {
 		color: var(--sl-color-text-accent);
 		box-shadow: inset 0 0 0 1px var(--sl-color-text-accent);
 	}


### PR DESCRIPTION
## Summary
Adds a back-link pill to the docs header so visitors can discover the rest of packetThrower from any deep page. Pattern lifted from Etch341's docs site.

## What it looks like
Header right side reads (left → right):
`[← packetThrower]` `[Docs]` `[GitHub icon]` `[Theme toggle]`

The first pill links absolute to `https://packetthrower.github.io/` (the parent landing page), the second to `/Baudrun/install/` (Docs entry point, unchanged).

## Implementation
- One `SocialIcons.astro` override (already a wrapper of Starlight's default).
- Renamed the shared style class `.bd-docs-link` → `.bd-nav-pill` since both pills share the look. Single class means future pills here stay visually consistent without three rules to keep in sync.
- Back-link uses an absolute URL because Astro's configured `base` is `/Baudrun/` — a relative `/` would resolve to this site's own root rather than the parent.
- Arrow wrapped in `<span aria-hidden="true">` so screen readers read the pill as "packetThrower" alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)