### PR TITLE
feat(i18n): locale plumbing + language picker (Phase A.1, #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ final stable entry at tag time.
 
 ## [Unreleased]
 
+### Added
+
+- **UI language setting (Settings → Appearance → Language).** First
+  step toward full localization ([#72](https://github.com/packetThrower/Baudrun/issues/72)).
+  Pick a language or leave it on "Auto" to follow the operating
+  system; the choice applies immediately across all open windows,
+  no restart. Simplified Chinese (简体中文) is the first non-English
+  option. At this stage only shared widget chrome (dropdowns,
+  dialogs, calendar) is translated — Baudrun's own labels and
+  messages are translated in a follow-up. Terminal output is never
+  translated.
+
 ## [0.14.0] — 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,19 @@ final stable entry at tag time.
 
 ### Added
 
-- **UI language setting (Settings → Appearance → Language).** First
-  step toward full localization ([#72](https://github.com/packetThrower/Baudrun/issues/72)).
-  Pick a language or leave it on "Auto" to follow the operating
-  system; the choice applies immediately across all open windows,
-  no restart. Simplified Chinese (简体中文) is the first non-English
-  option. At this stage only shared widget chrome (dropdowns,
-  dialogs, calendar) is translated — Baudrun's own labels and
-  messages are translated in a follow-up. Terminal output is never
-  translated.
+- **Simplified Chinese (简体中文) UI, and a language setting**
+  ([#72](https://github.com/packetThrower/Baudrun/issues/72)). The
+  entire app interface — sidebar, session header, profile editor,
+  settings, notifications, tooltips, context menus, dialogs — is now
+  translatable, with a full Simplified Chinese translation as the
+  first non-English language. Pick it under Settings → Appearance →
+  Language, or leave the setting on "Auto" to follow the operating
+  system's locale. Terminal output is never translated — only the
+  chrome around it. A language change applies across open windows
+  without a restart (dropdown option lists refresh when their form
+  is reopened). Additional languages are welcome as translation
+  contributions — one `locales/<lang>.yml` file plus a one-line
+  entry, no code changes.
 
 ## [0.14.0] — 2026-07-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,16 @@ CI (`.github/workflows/ci.yml`) runs `cargo check / clippy / test`
 on macOS, Windows, and Linux. Treat clippy warnings as build errors
 — the project keeps a clean lint baseline.
 
+## Translations
+
+Adding a language is one of the easiest ways to contribute and
+needs no Rust — copy `locales/en.yml` to `locales/<code>.yml`,
+translate the values, and add one line to `SUPPORTED` in
+`src/i18n.rs`. Native fluency (ideally from someone who consoles
+into gear in that language) matters far more than tooling; partial
+translations are fine — untranslated strings fall back to English.
+Full step-by-step in [`locales/README.md`](locales/README.md).
+
 ## AI-assisted contributions
 
 Baudrun is co-developed with Claude (see [AI-USAGE.md](AI-USAGE.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "plist",
  "regex",
  "rusb",
+ "rust-i18n",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serialport",
+ "sys-locale",
  "tempfile",
  "thiserror 2.0.18",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 dirs = "6"
 plist = "1"             # `.itermcolors` parsing in data::themes::parse
+rust-i18n = "4"         # UI string translation; locales/*.yml (issue #72)
 sys-locale = "0.3"      # OS locale detection for i18n::resolve (issue #72)
 thiserror = "2"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 dirs = "6"
 plist = "1"             # `.itermcolors` parsing in data::themes::parse
+sys-locale = "0.3"      # OS locale detection for i18n::resolve (issue #72)
 thiserror = "2"
 regex = "1"
 aho-corasick = "1"      # multi-keyword prefilter for highlight packs

--- a/TODO.md
+++ b/TODO.md
@@ -830,12 +830,50 @@ line-level streaming. Our regex engine is the right shape.
 
 ## Localization (i18n)
 
-**Status: deferred** until a non-English-speaking user actually
-files an issue asking for it. The network-engineer audience reads
-English manpages and CLI output all day, and the gear they're
-console-ing into doesn't speak French either — there's no clear
-demand signal yet. Notes below capture the survey from 2026-05-16
-so picking it up later doesn't require re-investigating.
+**Status: in progress** — issue #72 (@taotieren) requested it, so the
+demand signal arrived. Phase A.1 (locale plumbing + language picker)
+is on `feat/i18n`; `zh-CN` (Simplified Chinese) is the first target
+since the reporter writes it. Original 2026-05-16 survey preserved
+below; refinements from the 2026-07-09 PortFinder comparison are
+folded into the phase notes.
+
+**Refinements from building it (2026-07-09):**
+
+- **YAML, not TOML.** The survey said `.toml`; the sibling app
+  PortFinder shipped `.yml` and it's the better call — multiline
+  long tooltips + `#` comments for translators. rust-i18n v4 reads
+  both; A.2 uses `locales/*.yml`.
+- **Locale codes carry region/script.** `zh-CN`, not `zh` — must
+  match gpui-component's own code (`zh-CN`) so one `set_locale`
+  drives both layers, and because bare `zh` can't disambiguate
+  Simplified vs Traditional.
+- **Chinese-aware OS resolution.** PortFinder strips every OS locale
+  to its bare language subtag (`zh-Hans-CN` → `zh`), which never
+  matches a region-qualified `zh-CN` — a mainland user falls
+  through to English. `i18n::match_os_locale` keeps the script/
+  region subtags and routes Simplified (`Hans`/`CN`/`SG`/bare `zh`)
+  → `zh-CN`, Traditional (`Hant`/`TW`/`HK`/`MO`) → English until a
+  Traditional catalog ships. Unit-tested in `src/i18n.rs`.
+- **Multi-window propagation is NOT PortFinder's `cx.notify()`.**
+  PortFinder is single-window: its picker calls `set_locale` +
+  notifies its own view. Baudrun is multi-window — copying that
+  leaves other windows stale (the ProfilesBus bug class). Language
+  is a `Settings` field, so the change rides SettingsBus:
+  `AppView::apply_settings` gained `apply_locale`, which re-installs
+  the locale in EVERY window's subscription callback → all windows
+  re-render. Done in A.1.
+- **A.2 captured-label caveat.** `cx.notify()` re-languages anything
+  read fresh from `t!()` in `render`, and gpui-component's chrome
+  (which reads its own `t!()` per frame). But strings built once in
+  `::new` and stored — e.g. the Settings `SelectState` option
+  titles, `SettingsTab` tab labels — keep their construction-time
+  language until rebuilt. A.2 must either move those `Opt::new` /
+  tab-title lists into `render` or rebuild the `Select` entities on
+  a locale change (precedent: `set_system_dark` re-applies chrome on
+  OS appearance flips). The language picker's OWN options are
+  endonyms (each language in its own script), so they never need
+  re-translation — the caveat only bites once Baudrun's own labels
+  are extracted.
 
 ### Scope
 
@@ -850,7 +888,7 @@ so picking it up later doesn't require re-investigating.
 - Small enough that one translator volunteer can extract a new
   language in a 2–4 hour session.
 
-### Library choice: `rust-i18n` (TOML-backed)
+### Library choice: `rust-i18n` (YAML-backed — see refinement note above)
 
 [**`rust-i18n`**](https://crates.io/crates/rust-i18n) wins on
 consistency: it's already what `gpui-component` uses internally for
@@ -871,17 +909,23 @@ libintl dep that's overkill for ~180 strings). Both lose to
 
 ### Phased path
 
-- [ ] **Phase A.1 (30 min, free win).** Just call
-      `gpui_component::set_locale(&...)` from `main()` reading from
-      a new `Settings::locale: String` field (`""` → use the OS
-      locale via `sys-locale`). Doesn't translate any Baudrun
-      strings; does pick up gpui-component's existing en / zh-CN /
-      zh-HK / it widget translations for users whose OS is set to
-      one of those. Reversible if we change our mind later.
+- [x] **Phase A.1 (done — `feat/i18n`, issue #72).** `Settings::locale`
+      field (`""` → OS via `sys-locale`); `src/i18n.rs` resolver
+      (Chinese-aware, unit-tested); `i18n::init` calls
+      `gpui_component::set_locale` at boot; `AppView::apply_locale`
+      re-installs on every settings change so the picker propagates
+      to all windows. **Went beyond the original A.1** to also add
+      the Settings → Appearance → Language picker (endonym-labelled,
+      `""` = Auto) so the feature is user-controllable and testable
+      now, not only when the OS is already set to a shipped locale.
+      Still translates zero Baudrun strings — only gpui-component's
+      own chrome (dropdown/calendar/dialog) flips; the full Chinese
+      UI is A.2.
 
-- [ ] **Phase A.2 (~6–8 hr, on demand).** Full infrastructure: add
+- [ ] **Phase A.2 (~6–8 hr, the real cost).** Full infrastructure: add
       `rust-i18n = "4"` to Cargo.toml; extract every Baudrun string
-      into `locales/en.toml` with hierarchical keys
+      into `locales/en.yml` (YAML, see refinement note above) with
+      hierarchical keys
       (`notifications.connected_to`, `errors.port_in_use`,
       `buttons.undo`, `editor.fields.port_name_label`); replace
       string literals at call sites with `t!()` macro calls.
@@ -897,8 +941,10 @@ libintl dep that's overkill for ~180 strings). Both lose to
         (`"baudrun-default"`, `"cisco-ios"`, `"baudrun"`, …)
 
 - [ ] **Phase B (translator-only PRs).** Once a translator
-      volunteers a language, they add `locales/<lang>.toml` and a
-      one-line dropdown entry in the Settings → Language picker.
+      volunteers a language, they add `locales/<lang>.yml` and a
+      one-line `SUPPORTED` entry in `src/i18n.rs` (the Settings →
+      Language picker reads that list, so the dropdown updates
+      automatically).
       No core code changes.
 
 - [ ] **Phase C (deferred indefinitely).** RTL layout flip for

--- a/TODO.md
+++ b/TODO.md
@@ -955,11 +955,17 @@ libintl dep that's overkill for ~180 strings). Both lose to
       - Built-in theme / skin / highlight-pack IDs
         (`"baudrun-default"`, `"cisco-ios"`, `"baudrun"`, …)
 
-- [ ] **Phase B (translator-only PRs).** Once a translator
-      volunteers a language, they add `locales/<lang>.yml` and a
-      one-line `SUPPORTED` entry in `src/i18n.rs` (the Settings →
-      Language picker reads that list, so the dropdown updates
-      automatically).
+- [~] **Phase B (translator-only PRs) — on-ramp ready.** The
+      contribution path is documented: `locales/README.md` (canonical
+      step-by-step) + the docs "Authoring → Translations" page +
+      a CONTRIBUTING.md pointer. A translator adds `locales/<lang>.yml`
+      and a one-line `SUPPORTED` entry in `src/i18n.rs` (the Settings
+      → Language picker + OS auto-detection read that list, so both
+      update automatically); untranslated keys fall back to English.
+      Deliberately NOT bulk-machine-translating more languages —
+      quality in a technical UI depends on a native reviewer, so
+      each language waits for a speaker. Open item: wait for / invite
+      contributions.
       No core code changes.
 
 - [ ] **Phase C (deferred indefinitely).** RTL layout flip for

--- a/TODO.md
+++ b/TODO.md
@@ -922,7 +922,22 @@ libintl dep that's overkill for ~180 strings). Both lose to
       own chrome (dropdown/calendar/dialog) flips; the full Chinese
       UI is A.2.
 
-- [ ] **Phase A.2 (~6–8 hr, the real cost).** Full infrastructure: add
+- [x] **Phase A.2 (done — `feat/i18n`, #72).** `rust-i18n = "4"` +
+      `i18n!("locales", fallback = "en")`; all ~313 UI strings
+      extracted to `locales/en.yml` and wrapped in `t!()` across 7
+      files; full `locales/zh-CN.yml` Simplified Chinese translation.
+      Verified: every t!() key resolves, zh-CN structurally identical
+      (0 missing / 0 extra / 0 placeholder mismatch). **Remaining
+      polish (follow-up, not blocking):** dropdown `Select` OPTION
+      labels are built at form-open and only re-translate on reopen
+      during a LIVE language switch (everything rendered per-frame
+      updates instantly; a fresh launch in a locale is fully
+      translated). To make options live too: rebuild the editor +
+      Settings `Select` entities when the locale changes (precedent:
+      `set_system_dark` re-applies chrome on OS appearance flips).
+      Original A.2 detail retained below for reference.
+
+- [ ] **Phase A.2 — original plan (reference).** Full infrastructure: add
       `rust-i18n = "4"` to Cargo.toml; extract every Baudrun string
       into `locales/en.yml` (YAML, see refinement note above) with
       hierarchical keys

--- a/docs-next/astro.config.mjs
+++ b/docs-next/astro.config.mjs
@@ -110,6 +110,7 @@ export default defineConfig({
 						{ label: 'Terminal themes', slug: 'authoring/themes' },
 						{ label: 'App skins', slug: 'authoring/skins' },
 						{ label: 'Syntax highlighting', slug: 'authoring/highlighting' },
+						{ label: 'Translations', slug: 'authoring/translations' },
 						// Standalone HTML page in public/. The `attrs` field
 						// gives it the same external-link affordance as the
 						// GitHub social link.

--- a/docs-next/src/content/docs/authoring/translations.md
+++ b/docs-next/src/content/docs/authoring/translations.md
@@ -1,0 +1,57 @@
+---
+title: Translations
+description: 'Translate Baudrun into your language: one YAML file plus one line, no Rust required.'
+editUrl: https://github.com/packetThrower/Baudrun/edit/main/locales/README.md
+---
+
+Baudrun's interface can run in any language. Each language is a
+single YAML file under [`locales/`](https://github.com/packetThrower/Baudrun/tree/main/locales)
+named for its locale code — `en.yml`, `zh-CN.yml`, and whatever you
+add. English is both the source of truth and the fallback, so a
+partial translation is safe: any string you don't translate simply
+shows in English.
+
+You don't need to be a programmer. Native fluency — ideally from
+someone who actually consoles into gear in that language — matters
+far more than any tooling. A machine can produce 300 plausible
+strings; only a speaker knows whether "flow control" or
+"assert/deassert" reads right to an engineer.
+
+## The short version
+
+1. Copy `locales/en.yml` to `locales/<code>.yml` (BCP-47 code:
+   `de`, `fr`, `ja`, or language-Region where the script matters —
+   `zh-CN`, `zh-TW`, `pt-BR`).
+2. Translate the **values**, never the **keys**.
+3. Keep every `%{name}` placeholder (they're filled in at runtime).
+4. Leave technical tokens alone — `HEX`, `DTR`, `RTS`, `CR`/`LF`,
+   `XON/XOFF`, `USB`, `RS-485`, product names, hex examples,
+   keyboard combos, shell snippets.
+5. Add one line to `SUPPORTED` in
+   [`src/i18n.rs`](https://github.com/packetThrower/Baudrun/blob/main/src/i18n.rs)
+   with your code and the language's name in its own script:
+   `("de", "Deutsch")`. The language picker and OS auto-detection
+   pick it up automatically.
+6. `cargo run`, then Settings → Appearance → Language → your
+   language. It switches live.
+
+Open a PR with the `<code>.yml` file and the one-line `SUPPORTED`
+edit — that's the whole contribution.
+
+## Full guide
+
+The complete step-by-step (YAML quoting rules, the placeholder
+mechanics, the Traditional-Chinese resolver note, and the
+consistency tips) lives next to the files themselves, in
+[`locales/README.md`](https://github.com/packetThrower/Baudrun/blob/main/locales/README.md).
+That's the canonical reference — this page is the signpost.
+
+## What is and isn't translated
+
+Only the **chrome** — sidebar, session header, profile editor,
+settings, notifications, tooltips, menus, dialogs. **Terminal
+output is never translated**: the bytes your device emits pass
+through untouched, as they must. Wire-format identifiers (serial
+enum values like `cr`/`none`/`del`, profile JSON field names,
+theme/skin IDs) aren't display text and stay in code, never in the
+locale files.

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,0 +1,95 @@
+# Translating Baudrun
+
+Baudrun's interface can run in any language. Each language is one
+YAML file in this directory, named for its locale code:
+
+- `en.yml` — English (the source of truth **and** the fallback)
+- `zh-CN.yml` — Simplified Chinese
+- add your own: `de.yml`, `fr.yml`, `ja.yml`, `zh-TW.yml`, …
+
+You don't need to be a programmer to add a language — it's one file
+plus one line. Native fluency matters far more than Rust here; a
+translation from someone who actually uses console gear in that
+language is worth more than any machine output.
+
+## Add a language in 8 steps
+
+1. **Copy the English file** to your locale code:
+   `cp en.yml <code>.yml` (e.g. `de.yml`). Use the BCP-47 code —
+   two letters for most languages (`de`, `fr`, `ja`), or
+   language-Region where the script differs (`zh-CN` Simplified,
+   `zh-TW` Traditional, `pt-BR` Brazilian Portuguese).
+
+2. **Translate the values, never the keys.** Only change the text
+   to the *right* of each colon:
+   ```yaml
+   welcome:
+     pick_profile: "Pick a profile from the sidebar…"   # ← translate this
+   ```
+   Leave `welcome:` and `pick_profile:` exactly as they are — the
+   app looks strings up by those keys.
+
+3. **Keep every `%{name}` placeholder.** These are filled in at
+   runtime (a port name, a count, an error). Keep the name spelled
+   the same; you may move it to wherever it reads naturally:
+   ```yaml
+   connected: "Connected to %{port} @ %{baud}"
+   # German, placeholder reordered — fine:
+   connected: "Mit %{port} @ %{baud} verbunden"
+   ```
+
+4. **Leave technical tokens untranslated.** These are the same in
+   every language and translating them would confuse a network
+   engineer: `HEX`, `DTR`, `RTS`, `CR`, `LF`, `CRLF`, `XON/XOFF`,
+   `RTS/CTS`, `USB`, `UART`, `RS-485`, `Baudrun`, hex byte examples
+   like `02 FF AA 55`, keyboard combos (`⌘K`, `Ctrl+Shift`), and
+   shell/path snippets (`sudo chmod 666 …`, `.deb`, `settings.json`).
+   Product names (Cisco, PuTTY, GitHub) stay too.
+
+5. **Stay valid YAML.** Double-quote any value that contains a
+   colon, `%`, `#`, a straight `"`, or leading/trailing spaces;
+   escape an internal `"` as `\"` and a backslash as `\\` (the
+   line-ending options have literal backslashes like `CR (\\r)`).
+   When unsure, quote it — quoting is always safe.
+
+6. **Partial is fine.** Any key you leave out (or delete) falls
+   back to the English value automatically. Ship what you've done;
+   fill the rest in later. You never have to translate all ~300 at
+   once.
+
+7. **Register the language.** Add one line to the `SUPPORTED` list
+   in [`../src/i18n.rs`](../src/i18n.rs), with the locale code and
+   the language's name *in its own script* (its endonym, so a user
+   already in the wrong language can still find theirs):
+   ```rust
+   pub const SUPPORTED: &[(&str, &str)] =
+       &[("en", "English"), ("zh-CN", "简体中文"), ("de", "Deutsch")];
+   ```
+   The Settings → Appearance → Language picker reads this list, so
+   your language appears automatically. OS-locale auto-detection
+   also starts working for it (e.g. a `de-DE` system boots into
+   German). Traditional Chinese is pre-wired in the resolver —
+   adding `("zh-TW", "繁體中文")` + `zh-TW.yml` is all it takes.
+
+8. **Try it.** `cargo run`, then Settings → Appearance → Language →
+   your language. It switches live, no restart. Missing keys show
+   English, never a raw `some.key` string.
+
+## Tips
+
+- **Be consistent.** Pick one term per concept and use it
+  everywhere — a device's "baud rate" should read the same in
+  every string. Match how your OS and the gear's own docs render
+  networking terms.
+- **Keys are grouped by area** (`welcome.*`, `chrome.*` = sidebar/
+  header, `editor.*` = profile form, `settings.*`, `terminal.*`,
+  `opts.*` = dropdown options). The comments in `en.yml` say what
+  each area is.
+- **What's *not* here, on purpose:** serial values (`none`, `cr`,
+  `del`, …), profile JSON field names, and theme/skin IDs are
+  wire-format identifiers, not display text — they live in code and
+  are never translated. Terminal output (bytes from the device) is
+  never translated either; only the chrome around it.
+
+Open a PR with your `<code>.yml` and the one-line `SUPPORTED` edit.
+That's the whole contribution — thank you.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,18 @@
+_version: 2
+
+# English source strings for Baudrun's UI chrome. This is the
+# fallback locale (`i18n!(fallback = "en")`), so every key the app
+# calls via `t!()` MUST exist here; other locales may omit keys and
+# fall back to these values. Keys are hierarchical by UI area.
+# Interpolation uses rust-i18n's `%{name}` syntax.
+#
+# NOT translated (stay hardcoded, never `t!()`): profile JSON field
+# names, serial enum values ("none"/"cr"/"del"/…), and built-in
+# theme/skin/pack IDs — those are wire-format identifiers, not
+# display text. See TODO.md "Localization (i18n)".
+
+welcome:
+  # Idle right-pane splash when no session is active.
+  heading: Baudrun
+  pick_profile: Pick a profile from the sidebar to start a session.
+  create_first: Click the + above the profile list to create one.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,18 +1,365 @@
 _version: 2
 
-# English source strings for Baudrun's UI chrome. This is the
-# fallback locale (`i18n!(fallback = "en")`), so every key the app
-# calls via `t!()` MUST exist here; other locales may omit keys and
-# fall back to these values. Keys are hierarchical by UI area.
-# Interpolation uses rust-i18n's `%{name}` syntax.
+# English source strings for Baudrun's UI chrome — the `t!()` keys.
+# This is the fallback locale (`i18n!(fallback = "en")`): every key
+# the app calls MUST exist here; other locales may omit keys and fall
+# back to these. Keys are hierarchical by UI area. Interpolation uses
+# rust-i18n's `%{name}` syntax.
 #
-# NOT translated (stay hardcoded, never `t!()`): profile JSON field
-# names, serial enum values ("none"/"cr"/"del"/…), and built-in
-# theme/skin/pack IDs — those are wire-format identifiers, not
-# display text. See TODO.md "Localization (i18n)".
+# NOT translated (stay hardcoded, never t!()): profile JSON field
+# names, serial enum VALUES ("none"/"cr"/"del"/…), and built-in
+# theme/skin/pack IDs — wire-format identifiers, not display text.
+# Also left English on purpose: the settings filter-match keyword
+# tables (so search works regardless of UI language). See TODO.md.
 
 welcome:
-  # Idle right-pane splash when no session is active.
   heading: Baudrun
-  pick_profile: Pick a profile from the sidebar to start a session.
-  create_first: Click the + above the profile list to create one.
+  pick_profile: "Pick a profile from the sidebar to start a session."
+  create_first: "Click the + above the profile list to create one."
+
+terminal:
+  menu:
+    copy: Copy
+    paste: Paste
+    select_all: Select All
+    clear: Clear
+  paste_confirm:
+    title: "Paste multiple lines?"
+    body: "About to paste %{count} lines into the terminal."
+
+settings_chrome:
+  title: Settings
+  version_tooltip: "Baudrun version (from Cargo.toml at build time)"
+  global_defaults: GLOBAL DEFAULTS
+  filter_clear_tooltip: Clear filter
+  config_dir_unavailable: "(unavailable: %{err})"
+
+chrome:
+  move_session_to_new_window: Move Session to New Window
+  connect_in_new_window: Connect in New Window
+  send_break: Send Break
+  send_hex: "Send Hex…"
+  send_file: "Send File…"
+  move_to_new_window: Move to New Window
+  more_actions: More actions
+  session_suspended_title: Session suspended
+  suspended_banner_detail: "Port still open. Bytes keep flowing into scrollback."
+  session_suspended_heading: SESSION SUSPENDED
+  no_port: "(no port)"
+  suspended_pane_detail: "Port stays open; bytes keep flowing into scrollback."
+  resume_button: Resume
+  about_version: "Version %{version} (prototype)"
+  about_copyright: "© 2025–2026 packetThrower / Baudrun contributors"
+  view_on_github: View on GitHub
+  open_error: "open %{port}: %{base}"
+  open_error_permission_linux: "open %{port}: %{base} — your user can't access this serial port. Fix: install Baudrun's udev rule (already done if you used the .deb / .rpm / .pkg.tar.zst installer; rerun the installer if it didn't take), then unplug + replug the USB adapter. As a one-off workaround: `sudo chmod 666 %{port}` opens it for the current plug-in. The legacy dialout-group flow (`sudo usermod -aG dialout $USER` + log out + log in) also works."
+  reconnecting_suffix: " · reconnecting…"
+  dtr_asserted_tooltip: "DTR is asserted — click to deassert"
+  dtr_deasserted_tooltip: "DTR is deasserted — click to assert"
+  rts_asserted_tooltip: "RTS is asserted — click to deassert"
+  rts_deasserted_tooltip: "RTS is deasserted — click to assert"
+  clear_button: Clear
+  suspend_button: Suspend
+  suspend_tooltip: "Keep session alive; return to profile"
+  disconnect_button: Disconnect
+  reconnecting: "Reconnecting to %{port} @ %{baud}…"
+  connected: "Connected to %{port} @ %{baud}"
+  editing: "Editing %{name}"
+  editing_new: Editing new profile
+  not_connected: Not connected
+  chip_hex: HEX
+  chip_time: TIME
+  chip_line: "LINE#"
+  chip_to_file: TO FILE
+  scrollback_tooltip: "Scrollback lines: filled / max"
+  collapse_sidebar_tooltip: Collapse sidebar
+  expand_sidebar_tooltip: Expand sidebar
+  profiles_label: PROFILES
+  new_profile_tooltip: New profile
+  new_window_tooltip: New window
+  settings_tooltip: Settings
+
+app:
+  about_title: About Baudrun
+  auto_reconnect_gave_up: "Auto-reconnect to %{port} gave up after 15 attempts"
+  break_failed: "Couldn't send break: %{error}"
+  break_sent: Break sent
+  cancel: Cancel
+  choose_file_prompt: Choose a file to send
+  connect_before_file: Connect to a port before sending a file.
+  connect_before_hex: Connect to a port before sending hex.
+  connected: "Connected to %{port} @ %{baud}"
+  disconnected: Disconnected
+  dtr_asserted: DTR asserted
+  dtr_deasserted: DTR deasserted
+  dtr_toggle_failed: "DTR toggle failed: session closed"
+  file: File
+  file_fallback: file
+  font_size: "Font size: %{size}"
+  font_size_update_failed: "Font size update failed: %{error}"
+  hex_empty: empty
+  invalid: "Invalid: %{error}"
+  move_session_failed: "Move session failed: %{error}"
+  no_port: no port set
+  no_port_set: profile has no port set
+  not_connected: not connected
+  open_unknown: "open %{port}: unknown"
+  profile_gone: profile no longer exists
+  profile_not_found: profile not found
+  protocol: Protocol
+  read_file_failed: "Couldn't read file: %{error}"
+  reconnected: Reconnected
+  removed_profile: "Removed profile “%{name}”"
+  reorder_failed: "Couldn't reorder profile: %{error}"
+  restore_failed: "Couldn't restore profile: %{error}"
+  restored_profile: "Restored profile “%{name}”"
+  rts_asserted: RTS asserted
+  rts_deasserted: RTS deasserted
+  rts_toggle_failed: "RTS toggle failed: session closed"
+  save_failed: "Save failed: %{error}"
+  saved: Saved
+  send: Send
+  send_file_help: "Start the receiver on the target device first (rx, loady, bootloader “Receive File” menu, etc.) before clicking Send. The transfer waits up to 60 s for the receiver's handshake before giving up."
+  send_file_title: Send file
+  send_hex_help: "Space-separated, compact, or 0x-prefixed — all equivalent: 02 FF AA 55, 02FFAA55, 0x02 0xFF 0xAA 0x55."
+  send_hex_title: Send hex bytes
+  sending_file: "Sending “%{name}”"
+  sent_byte_one: "Sent %{count} byte"
+  sent_bytes_many: "Sent %{count} bytes"
+  sent_file: "Sent “%{name}”"
+  session_dropped_no_reconnect: Session dropped (auto-reconnect off)
+  session_dropped_profile_gone: "session dropped (profile %{id} no longer exists)"
+  session_dropped_reconnecting: "Session dropped — auto-reconnecting…"
+  session_log: "Session log: %{path}"
+  session_log_open_failed: "Session log open failed: %{error}"
+  session_moved: Session moved to new window
+  session_suspended: Session kept alive in background
+  settings_window_title: "Settings · Baudrun"
+  transfer_failed: "Transfer failed: %{error}"
+  undo: Undo
+  unknown_file: "(unknown)"
+  unnamed: "(unnamed)"
+
+editor:
+  name_placeholder: My switch
+  custom_suffix: "%{name} (custom)"
+  subtitle_edit: EDIT PROFILE
+  subtitle_new: NEW PROFILE
+  unnamed_title: "(unnamed)"
+  delete_button: Delete
+  save_button: Save
+  cancel_button: Cancel
+  disconnect_button: Disconnect
+  resume_button: Resume
+  connect_button: Connect
+  advanced_desc: Control lines, hex view, timestamps, session logging.
+  control_lines_desc: "Only needed for specific adapters or devices (RS-485 direction, Arduino DTR-reset, firmwares that key off DTR for session lifecycle)."
+  tab:
+    connection: Connection
+    highlighting: Highlighting
+    advanced: Advanced
+  section:
+    terminal: Terminal
+    control_lines: Control Lines
+    output: Output
+    paste_safety: Paste safety
+  field:
+    name: NAME
+    serial_port: SERIAL PORT
+    baud_rate: BAUD RATE
+    data_bits: DATA BITS
+    parity: PARITY
+    stop_bits: STOP BITS
+    flow_control: FLOW CONTROL
+    send_line_ending: SEND LINE ENDING
+    backspace_sends: BACKSPACE SENDS
+    local_echo: Local echo
+    dtr_on_connect: DTR ON CONNECT
+    rts_on_connect: RTS ON CONNECT
+    dtr_on_disconnect: DTR ON DISCONNECT
+    rts_on_disconnect: RTS ON DISCONNECT
+    slow_paste_delay: SLOW-PASTE DELAY (MS)
+  theme:
+    use_global_default: Use global default
+    title: Terminal Theme
+    desc: "Override the global default theme just for this profile. Useful for keeping different palettes on different devices (e.g. red-tinged for production routers, calm green for the lab switch). Leave on “Use global default” to inherit from Settings → Themes."
+  driver:
+    usb_device: USB device
+    serial_prefix: " · serial "
+    not_loaded_title: "%{chipset} detected — driver not loaded"
+    install_button: "Install driver…"
+  highlight:
+    master_desc: Master switch for this profile. When off, incoming output is rendered without any rule-based colouring regardless of which packs are enabled below.
+    master_toggle: Highlight terminal output for this profile
+    override_toggle: Override global pack selection
+    packs_title: Highlight Packs
+    packs_desc: "Inherit the global selection from Settings, or override it for this profile. With override off, the rows show what the global is currently broadcasting (read-only)."
+  output:
+    timestamps: Line timestamps
+    timestamps_hint: prefix each line with wall-clock time
+    line_numbers: Line numbers
+    line_numbers_hint: prefix each line with a session-local counter (resets on reconnect)
+    hex_view: Hex view
+    hex_view_hint: show incoming bytes as hex dump
+    log_enabled: Record session to file
+    log_enabled_hint: "raw bytes; destination set in Settings → Advanced"
+    auto_reconnect: Auto-reconnect on drop
+    auto_reconnect_hint: poll for the port to reappear (up to 30s) and reopen transparently
+  paste:
+    warn_multiline: Confirm multi-line pastes
+    warn_multiline_hint: prompt before sending pasted text that contains line breaks
+    slow: Slow paste
+    slow_hint: send one char at a time with a delay
+    safety_desc: "Catch the “I pasted into the wrong window” mistake, and pace pastes so UARTs on slower devices don't drop bytes."
+
+opts:
+  baud:
+    "9600": "9600 (default)"
+  parity:
+    none: None
+    odd: Odd
+    even: Even
+    mark: Mark
+    space: Space
+  flow_control:
+    none: None
+    rtscts: RTS/CTS
+    xonxoff: XON/XOFF
+  line_ending:
+    cr: "CR (\\r) — switches, routers"
+    lf: "LF (\\n) — Linux consoles"
+    crlf: "CRLF (\\r\\n) — legacy / Windows"
+  line_policy:
+    default: Default (leave as-is)
+    assert: Assert (high)
+    deassert: Deassert (low)
+  backspace:
+    del: "DEL (0x7F) — VT100, xterm, modern"
+    bs: "BS (0x08) — older Cisco, Foundry"
+  port_not_connected: "%{port} (not connected)"
+
+settings:
+  tab:
+    appearance: Appearance
+    themes: Themes
+    shortcuts: Shortcuts
+    highlighting: Highlighting
+    accessibility: Accessibility
+    updates: Updates
+    advanced: Advanced
+  appearance_auto: Auto (follow system)
+  appearance_light: Light
+  appearance_dark: Dark
+  language_auto: Auto (follow system)
+  log_dir_placeholder: Default
+  filter_placeholder: "Filter settings…"
+  app_skin_title: App Skin
+  app_skin_desc: "How the app chrome (sidebar, panes, buttons) looks. Doesn't affect the terminal palette — that's the Themes tab."
+  appearance_title: Appearance
+  appearance_desc: "Light or dark variant of the active skin. \"Auto\" follows the system setting. Skins flagged dark-only ignore this and pin dark."
+  language_title: Language
+  language_desc: "UI language. \"Auto\" follows the operating system. Takes effect immediately — no restart. Terminal output is never translated."
+  font_size_title: Terminal Font Size
+  font_size_desc: "Pixel size of the terminal pane's monospace font. Leave blank to use the default (13). Changes the terminal grid only — chrome text size is fixed."
+  scrollback_title: Scrollback
+  scrollback_desc: "Lines of terminal output retained for mouse-wheel scrollback. Higher values use more memory but let you scroll further back through chatty sessions. Leave blank to use the default (10000)."
+  installed_skins_title: Installed Skins
+  no_custom_skins: No custom skins installed. Use Import to add a skin JSON file.
+  default_theme_title: Default Theme
+  default_theme_desc: Used by any profile that doesn't set its own theme.
+  theme_label: Theme
+  installed_themes_title: Installed Themes
+  import_itermcolors: "Import .itermcolors…"
+  tag_custom: Custom
+  tag_builtin: Built-in
+  tag_custom_dark_only: "Custom · dark-only"
+  preview: Preview
+  import_skin: "Import skin…"
+  import_pack: "Import pack…"
+  highlight_packs_title: Highlight Packs
+  highlight_packs_desc: "Choose which built-in or imported rule packs colorize terminal output. Stack as many as you want — matches from each pack are merged in order. With every box unchecked highlighting is off, even if a profile has it enabled."
+  tip:
+    delete_theme: Delete imported theme
+    delete_pack: Delete imported pack
+    remove_skin: Remove imported skin
+  capture_prompt: "Press a key… (Esc to cancel)"
+  keyboard_shortcuts_title: Keyboard Shortcuts
+  keyboard_shortcuts_desc: "Click a binding to record a new key combo; Escape cancels. Use ↺ to reset that row to the platform default. macOS uses Cmd-based combos (Cmd is never a terminal control character so plain ⌘K is safe); Linux/Windows use Ctrl+Shift so plain Ctrl+letter still passes through to the device."
+  reduce_motion_title: Reduce Motion
+  reduce_motion_desc: Honours the OS preference for reduced motion. Read from the system at launch; no per-app override.
+  reduce_motion:
+    status_on: "On — Baudrun is skipping the reconnect-dot pulse and holding the terminal cursor steady."
+    status_off: "Off — Baudrun's optional animations (reconnect-dot pulse, terminal cursor blink) are on."
+    path_macos: "Change at System Settings → Accessibility → Display → “Reduce motion”."
+    path_windows: "Change at Settings → Accessibility → Visual effects → “Animation effects”."
+    path_other: Change via your desktop environment's accessibility / animation settings.
+    stale_note: Detected once at app launch. Relaunch Baudrun after flipping the system setting if a value here looks stale.
+  updates_title: Updates
+  updates_desc: "Baudrun queries GitHub Releases once at app launch for a newer version. No automatic download — when an update is available the sidebar's gear icon gets an amber dot and this pane shows the new version with a button to open the Releases page."
+  update_prefs_title: Update Preferences
+  update_prefs_desc: "Disable the check entirely, or opt into seeing pre-release tags (`-alpha.*` / `-beta.*` / `-rc.*`)."
+  updates:
+    checks_disabled: Update checks are disabled.
+    available_dismissed: "v%{version} is available — you've dismissed this version."
+    available: "v%{version} is available."
+    up_to_date: Baudrun is up to date.
+    current_version: "Currently running v%{version}."
+    view_release: View release
+    dismiss: Dismiss this version
+    check_on_launch: Check for updates on launch
+    include_prerelease: Include pre-releases (alpha / beta / rc)
+  log_dir_title: Session Log Directory
+  log_dir_desc: "Where profiles with \"Record session to file\" enabled write their logs. Leave blank to use the default."
+  choose: "Choose…"
+  reset: Reset
+  reveal: Reveal
+  usb_driver_title: USB Driver Detection
+  usb_driver_desc: Show a banner in the profile form when a USB-serial adapter is plugged in without its vendor driver installed.
+  usb_driver_toggle: Detect un-drivered USB adapters
+  copy_on_select_title: Copy on Select
+  copy_on_select_desc: "PuTTY-style — copy the terminal selection to the clipboard automatically when the mouse is released. Avoids having to press ⌘/Ctrl+C for every snippet."
+  copy_on_select_toggle: Copy terminal selection to clipboard automatically
+  window_state_title: Window State
+  window_state_desc: "Reopen Baudrun and Settings windows where you left them. Turn off to land at the centered default size each launch instead. The Reset buttons clear the saved geometry and resize the matching live windows immediately."
+  window_state_toggle: Restore window size and position on launch
+  reset_settings_window: Reset Settings window
+  reset_main_window: Reset main window
+  config_dir_title: Config Directory
+  config_dir_desc: "Where Baudrun stores profiles, themes, skins, highlight packs, and settings.json. Choose a different location to share configs across machines (Dropbox, iCloud Drive, dotfile repo) or to test from a clean directory. Takes effect on the next launch."
+  theme_preview:
+    subtitle_imported: "Imported theme · sample output · last line shows text selection"
+    subtitle_builtin: "Built-in theme · sample output · last line shows text selection"
+  undo: Undo
+  prompt:
+    choose_config_dir: Choose Baudrun config directory
+    choose_log_dir: Choose session log directory
+    import_skin: Import skin JSON
+    import_theme: "Import theme (.itermcolors or JSON)"
+    import_pack: Import highlight pack JSON
+  toast:
+    save_failed: "Couldn't save settings: %{err}"
+    config_open_failed: "Couldn't open config directory: %{err}"
+    config_set: Config directory set. Restart Baudrun to use it.
+    config_set_failed: "Couldn't set config directory: %{err}"
+    config_reset: Config directory reset. Restart Baudrun to use the default.
+    config_reset_failed: "Couldn't reset config directory: %{err}"
+    log_dir_updated: Log directory updated
+    log_dir_reset: Log directory reset to default
+    skin_imported: "Imported skin “%{name}”"
+    skin_import_failed: "Couldn't import skin: %{err}"
+    skin_removed: "Removed skin “%{name}”"
+    skin_delete_failed: "Couldn't delete skin: %{err}"
+    skin_restored: "Restored skin “%{name}”"
+    skin_restore_failed: "Couldn't restore skin: %{err}"
+    theme_imported: "Imported theme “%{name}”"
+    theme_import_failed: "Couldn't import theme: %{err}"
+    theme_removed: "Removed theme “%{name}”"
+    theme_delete_failed: "Couldn't delete theme: %{err}"
+    theme_restored: "Restored theme “%{name}”"
+    theme_restore_failed: "Couldn't restore theme: %{err}"
+    pack_imported: "Imported pack “%{name}”"
+    pack_import_failed: "Couldn't import pack: %{err}"
+    pack_removed: "Removed pack “%{name}”"
+    pack_delete_failed: "Couldn't delete pack: %{err}"
+    pack_restored: "Restored pack “%{name}”"
+    pack_restore_failed: "Couldn't restore pack: %{err}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,4 +1,4 @@
-_version: 2
+_version: 1
 
 # English source strings for Baudrun's UI chrome — the `t!()` keys.
 # This is the fallback locale (`i18n!(fallback = "en")`): every key

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -1,4 +1,4 @@
-_version: 2
+_version: 1
 # Simplified Chinese (简体中文, zh-CN) for Baudrun's UI chrome — issue #72.
 
 welcome:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -1,0 +1,12 @@
+_version: 2
+
+# Simplified Chinese (简体中文). Keys mirror en.yml; any key omitted
+# here falls back to the English value. First non-English locale —
+# requested in issue #72. Terminology note for translators:
+# serial/networking terms follow mainland conventions (串口 = serial
+# port, 波特率 = baud rate, 校验 = parity, 会话 = session).
+
+welcome:
+  heading: Baudrun
+  pick_profile: 从侧边栏选择一个配置以开始会话。
+  create_first: 点击配置列表上方的 + 号来创建一个。

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -1,12 +1,354 @@
 _version: 2
-
-# Simplified Chinese (简体中文). Keys mirror en.yml; any key omitted
-# here falls back to the English value. First non-English locale —
-# requested in issue #72. Terminology note for translators:
-# serial/networking terms follow mainland conventions (串口 = serial
-# port, 波特率 = baud rate, 校验 = parity, 会话 = session).
+# Simplified Chinese (简体中文, zh-CN) for Baudrun's UI chrome — issue #72.
 
 welcome:
   heading: Baudrun
-  pick_profile: 从侧边栏选择一个配置以开始会话。
-  create_first: 点击配置列表上方的 + 号来创建一个。
+  pick_profile: "从侧边栏选择一个配置以开始会话。"
+  create_first: "点击配置列表上方的 + 来创建一个。"
+
+terminal:
+  menu:
+    copy: 复制
+    paste: 粘贴
+    select_all: 全选
+    clear: 清除
+  paste_confirm:
+    title: "粘贴多行？"
+    body: "即将向终端粘贴 %{count} 行。"
+
+settings_chrome:
+  title: 设置
+  version_tooltip: "Baudrun 版本（构建时取自 Cargo.toml）"
+  global_defaults: 全局默认
+  filter_clear_tooltip: 清除筛选
+  config_dir_unavailable: "（不可用：%{err}）"
+
+chrome:
+  move_session_to_new_window: 移动会话到新窗口
+  connect_in_new_window: 在新窗口中连接
+  send_break: "发送 Break"
+  send_hex: "发送十六进制…"
+  send_file: "发送文件…"
+  move_to_new_window: 移动到新窗口
+  more_actions: 更多操作
+  session_suspended_title: 会话已挂起
+  suspended_banner_detail: "串口仍打开。字节持续写入回滚缓冲。"
+  session_suspended_heading: 会话已挂起
+  no_port: "（无串口）"
+  suspended_pane_detail: "串口保持打开；字节持续写入回滚缓冲。"
+  resume_button: 恢复
+  about_version: "版本 %{version}（原型）"
+  about_copyright: "© 2025–2026 packetThrower / Baudrun 贡献者"
+  view_on_github: "在 GitHub 上查看"
+  open_error: "打开 %{port}：%{base}"
+  open_error_permission_linux: "打开 %{port}：%{base} — 当前用户无法访问此串口。解决方法：安装 Baudrun 的 udev 规则（如果你使用了 .deb / .rpm / .pkg.tar.zst 安装程序则已完成；若未生效，请重新运行安装程序），然后拔下并重新插上 USB 适配器。作为一次性的临时办法：`sudo chmod 666 %{port}` 可为当前插入的设备打开访问权限。传统的 dialout 组方式（`sudo usermod -aG dialout $USER` + 注销 + 重新登录）同样有效。"
+  reconnecting_suffix: " · 重连中…"
+  dtr_asserted_tooltip: "DTR 已置位 — 点击取消置位"
+  dtr_deasserted_tooltip: "DTR 已取消置位 — 点击置位"
+  rts_asserted_tooltip: "RTS 已置位 — 点击取消置位"
+  rts_deasserted_tooltip: "RTS 已取消置位 — 点击置位"
+  clear_button: 清除
+  suspend_button: 挂起
+  suspend_tooltip: "保持会话存活；返回配置"
+  disconnect_button: 断开连接
+  reconnecting: "正在重连到 %{port} @ %{baud}…"
+  connected: "已连接到 %{port} @ %{baud}"
+  editing: "正在编辑 %{name}"
+  editing_new: 正在编辑新配置
+  not_connected: 未连接
+  chip_hex: HEX
+  chip_time: 时间
+  chip_line: "行号"
+  chip_to_file: 写入文件
+  scrollback_tooltip: "回滚缓冲行数：已用 / 上限"
+  collapse_sidebar_tooltip: 折叠侧边栏
+  expand_sidebar_tooltip: 展开侧边栏
+  profiles_label: 配置
+  new_profile_tooltip: 新建配置
+  new_window_tooltip: 新建窗口
+  settings_tooltip: 设置
+
+app:
+  about_title: "关于 Baudrun"
+  auto_reconnect_gave_up: "自动重连到 %{port} 在尝试 15 次后放弃"
+  break_failed: "无法发送 Break：%{error}"
+  break_sent: "Break 已发送"
+  cancel: 取消
+  choose_file_prompt: 选择要发送的文件
+  connect_before_file: 发送文件前请先连接到串口。
+  connect_before_hex: 发送十六进制前请先连接到串口。
+  connected: "已连接到 %{port} @ %{baud}"
+  disconnected: 已断开连接
+  dtr_asserted: "DTR 已置位"
+  dtr_deasserted: "DTR 已取消置位"
+  dtr_toggle_failed: "DTR 切换失败：会话已关闭"
+  file: 文件
+  file_fallback: 文件
+  font_size: "字号：%{size}"
+  font_size_update_failed: "字号更新失败：%{error}"
+  hex_empty: 空
+  invalid: "无效：%{error}"
+  move_session_failed: "移动会话失败：%{error}"
+  no_port: 未设置串口
+  no_port_set: 配置未设置串口
+  not_connected: 未连接
+  open_unknown: "打开 %{port}：未知"
+  profile_gone: 配置已不存在
+  profile_not_found: 未找到配置
+  protocol: 协议
+  read_file_failed: "无法读取文件：%{error}"
+  reconnected: 已重连
+  removed_profile: "已删除配置“%{name}”"
+  reorder_failed: "无法重新排序配置：%{error}"
+  restore_failed: "无法恢复配置：%{error}"
+  restored_profile: "已恢复配置“%{name}”"
+  rts_asserted: "RTS 已置位"
+  rts_deasserted: "RTS 已取消置位"
+  rts_toggle_failed: "RTS 切换失败：会话已关闭"
+  save_failed: "保存失败：%{error}"
+  saved: 已保存
+  send: 发送
+  send_file_help: "点击发送前，请先在目标设备上启动接收方（rx、loady、引导加载程序的“Receive File”菜单等）。传输会等待接收方握手最多 60 秒后放弃。"
+  send_file_title: 发送文件
+  send_hex_help: "空格分隔、紧凑或 0x 前缀 — 三者等价：02 FF AA 55、02FFAA55、0x02 0xFF 0xAA 0x55。"
+  send_hex_title: 发送十六进制字节
+  sending_file: "正在发送“%{name}”"
+  sent_byte_one: "已发送 %{count} 字节"
+  sent_bytes_many: "已发送 %{count} 字节"
+  sent_file: "已发送“%{name}”"
+  session_dropped_no_reconnect: "会话已掉线（自动重连关闭）"
+  session_dropped_profile_gone: "会话已掉线（配置 %{id} 已不存在）"
+  session_dropped_reconnecting: "会话已掉线 — 正在自动重连…"
+  session_log: "会话日志：%{path}"
+  session_log_open_failed: "会话日志打开失败：%{error}"
+  session_moved: 会话已移动到新窗口
+  session_suspended: 会话已在后台保持存活
+  settings_window_title: "设置 · Baudrun"
+  transfer_failed: "传输失败：%{error}"
+  undo: 撤销
+  unknown_file: "（未知）"
+  unnamed: "（未命名）"
+
+editor:
+  name_placeholder: 我的交换机
+  custom_suffix: "%{name}（自定义）"
+  subtitle_edit: 编辑配置
+  subtitle_new: 新建配置
+  unnamed_title: "（未命名）"
+  delete_button: 删除
+  save_button: 保存
+  cancel_button: 取消
+  disconnect_button: 断开连接
+  resume_button: 恢复
+  connect_button: 连接
+  advanced_desc: "控制线、十六进制视图、时间戳、会话日志。"
+  control_lines_desc: "仅特定适配器或设备需要（RS-485 方向控制、Arduino DTR 复位、以 DTR 控制会话生命周期的固件）。"
+  tab:
+    connection: 连接
+    highlighting: 高亮
+    advanced: 高级
+  section:
+    terminal: 终端
+    control_lines: 控制线
+    output: 输出
+    paste_safety: 粘贴安全
+  field:
+    name: 名称
+    serial_port: 串口
+    baud_rate: 波特率
+    data_bits: 数据位
+    parity: 校验
+    stop_bits: 停止位
+    flow_control: 流控
+    send_line_ending: 发送行结束符
+    backspace_sends: 退格键发送
+    local_echo: 本地回显
+    dtr_on_connect: "连接时 DTR"
+    rts_on_connect: "连接时 RTS"
+    dtr_on_disconnect: "断开时 DTR"
+    rts_on_disconnect: "断开时 RTS"
+    slow_paste_delay: "慢速粘贴延迟（毫秒）"
+  theme:
+    use_global_default: 使用全局默认
+    title: 终端主题
+    desc: "仅为此配置覆盖全局默认主题。适合在不同设备上使用不同的配色（例如生产路由器用偏红色调，实验室交换机用柔和的绿色）。保持“使用全局默认”即可从 设置 → 主题 继承。"
+  driver:
+    usb_device: "USB 设备"
+    serial_prefix: " · 序列号 "
+    not_loaded_title: "检测到 %{chipset} — 驱动未加载"
+    install_button: "安装驱动…"
+  highlight:
+    master_desc: "此配置的总开关。关闭时，无论下方启用了哪些规则包，接收到的输出都不会应用任何基于规则的着色。"
+    master_toggle: 为此配置高亮终端输出
+    override_toggle: 覆盖全局规则包选择
+    packs_title: 高亮规则包
+    packs_desc: "从设置继承全局选择，或为此配置覆盖它。关闭覆盖时，这些行显示全局当前生效的内容（只读）。"
+  output:
+    timestamps: 行时间戳
+    timestamps_hint: 在每行前加上挂钟时间
+    line_numbers: 行号
+    line_numbers_hint: "在每行前加上会话内计数器（重连时重置）"
+    hex_view: 十六进制视图
+    hex_view_hint: 以十六进制转储显示接收到的字节
+    log_enabled: 将会话记录到文件
+    log_enabled_hint: "原始字节；目标位置在 设置 → 高级 中设置"
+    auto_reconnect: 掉线时自动重连
+    auto_reconnect_hint: "轮询等待串口重新出现（最多 30 秒）并透明地重新打开"
+  paste:
+    warn_multiline: 确认多行粘贴
+    warn_multiline_hint: 在发送包含换行的粘贴文本前提示
+    slow: 慢速粘贴
+    slow_hint: 每次发送一个字符并带延迟
+    safety_desc: "捕捉“粘贴到了错误窗口”这类失误，并控制粘贴节奏，以免较慢设备上的 UART 丢失字节。"
+
+opts:
+  baud:
+    "9600": "9600（默认）"
+  parity:
+    none: 无
+    odd: 奇
+    even: 偶
+    mark: 标记
+    space: 空格
+  flow_control:
+    none: 无
+    rtscts: RTS/CTS
+    xonxoff: XON/XOFF
+  line_ending:
+    cr: "CR (\\r) — 交换机、路由器"
+    lf: "LF (\\n) — Linux 控制台"
+    crlf: "CRLF (\\r\\n) — 旧式 / Windows"
+  line_policy:
+    default: "默认（保持不变）"
+    assert: "置位（高）"
+    deassert: "取消置位（低）"
+  backspace:
+    del: "DEL (0x7F) — VT100、xterm、现代终端"
+    bs: "BS (0x08) — 较旧的 Cisco、Foundry"
+  port_not_connected: "%{port}（未连接）"
+
+settings:
+  tab:
+    appearance: 外观
+    themes: 主题
+    shortcuts: 快捷键
+    highlighting: 高亮
+    accessibility: 辅助功能
+    updates: 更新
+    advanced: 高级
+  appearance_auto: "自动（跟随系统）"
+  appearance_light: 浅色
+  appearance_dark: 深色
+  language_auto: "自动（跟随系统）"
+  log_dir_placeholder: 默认
+  filter_placeholder: "筛选设置…"
+  app_skin_title: 应用皮肤
+  app_skin_desc: "应用界面（侧边栏、窗格、按钮）的外观。不影响终端配色 — 那由主题标签页控制。"
+  appearance_title: 外观
+  appearance_desc: "当前皮肤的浅色或深色变体。“自动”跟随系统设置。标记为仅深色的皮肤会忽略此项并固定为深色。"
+  language_title: 语言
+  language_desc: "界面语言。“自动”跟随操作系统。立即生效 — 无需重启。终端输出永不翻译。"
+  font_size_title: 终端字号
+  font_size_desc: "终端窗格等宽字体的像素大小。留空则使用默认值（13）。仅改变终端网格 — 界面文字大小固定。"
+  scrollback_title: 回滚缓冲
+  scrollback_desc: "为鼠标滚轮回滚保留的终端输出行数。数值越大占用内存越多，但可以在输出频繁的会话中回滚得更远。留空则使用默认值（10000）。"
+  installed_skins_title: 已安装皮肤
+  no_custom_skins: "未安装自定义皮肤。使用导入来添加皮肤 JSON 文件。"
+  default_theme_title: 默认主题
+  default_theme_desc: 供任何未设置自己主题的配置使用。
+  theme_label: 主题
+  installed_themes_title: 已安装主题
+  import_itermcolors: "导入 .itermcolors…"
+  tag_custom: 自定义
+  tag_builtin: 内置
+  tag_custom_dark_only: "自定义 · 仅深色"
+  preview: 预览
+  import_skin: "导入皮肤…"
+  import_pack: "导入规则包…"
+  highlight_packs_title: 高亮规则包
+  highlight_packs_desc: "选择哪些内置或导入的规则包为终端输出着色。可叠加任意多个 — 各规则包的匹配会按顺序合并。当所有复选框都未勾选时，即使某个配置已启用高亮，高亮也会关闭。"
+  tip:
+    delete_theme: 删除导入的主题
+    delete_pack: 删除导入的规则包
+    remove_skin: 移除导入的皮肤
+  capture_prompt: "按下一个键…（Esc 取消）"
+  keyboard_shortcuts_title: 键盘快捷键
+  keyboard_shortcuts_desc: "点击某个绑定以录制新的组合键；按 Escape 取消。使用 ↺ 将该行重置为平台默认值。macOS 使用基于 Cmd 的组合键（Cmd 从不是终端控制字符，因此单独的 ⌘K 是安全的）；Linux/Windows 使用 Ctrl+Shift，这样单独的 Ctrl+字母 仍能传递到设备。"
+  reduce_motion_title: 减弱动态效果
+  reduce_motion_desc: "遵循操作系统的减弱动态效果偏好。在启动时从系统读取；无应用级覆盖。"
+  reduce_motion:
+    status_on: "开 — Baudrun 正在跳过重连圆点的脉动，并让终端光标保持静止。"
+    status_off: "关 — Baudrun 的可选动画（重连圆点脉动、终端光标闪烁）已开启。"
+    path_macos: "在 系统设置 → 辅助功能 → 显示 → “减弱动态效果” 中更改。"
+    path_windows: "在 设置 → 辅助功能 → 视觉效果 → “动画效果” 中更改。"
+    path_other: 通过你的桌面环境的辅助功能 / 动画设置进行更改。
+    stale_note: "仅在应用启动时检测一次。如果此处的值看起来过时，请在更改系统设置后重新启动 Baudrun。"
+  updates_title: 更新
+  updates_desc: "Baudrun 在应用启动时向 GitHub Releases 查询一次是否有更新版本。不会自动下载 — 当有可用更新时，侧边栏的齿轮图标会出现一个琥珀色圆点，此窗格会显示新版本并附带一个打开 Releases 页面的按钮。"
+  update_prefs_title: 更新偏好
+  update_prefs_desc: "完全禁用检查，或选择查看预发布标签（`-alpha.*` / `-beta.*` / `-rc.*`）。"
+  updates:
+    checks_disabled: 更新检查已禁用。
+    available_dismissed: "v%{version} 可用 — 你已忽略此版本。"
+    available: "v%{version} 可用。"
+    up_to_date: "Baudrun 已是最新版本。"
+    current_version: "当前运行 v%{version}。"
+    view_release: 查看发布
+    dismiss: 忽略此版本
+    check_on_launch: 启动时检查更新
+    include_prerelease: "包含预发布版本（alpha / beta / rc）"
+  log_dir_title: 会话日志目录
+  log_dir_desc: "启用了“将会话记录到文件”的配置写入日志的位置。留空则使用默认值。"
+  choose: "选择…"
+  reset: 重置
+  reveal: 在文件夹中显示
+  usb_driver_title: "USB 驱动检测"
+  usb_driver_desc: "当插入 USB 串口适配器但未安装其厂商驱动时，在配置表单中显示横幅。"
+  usb_driver_toggle: "检测缺少驱动的 USB 适配器"
+  copy_on_select_title: 选中即复制
+  copy_on_select_desc: "PuTTY 风格 — 释放鼠标时自动将终端选区复制到剪贴板。免去每次都要按 ⌘/Ctrl+C。"
+  copy_on_select_toggle: 自动将终端选区复制到剪贴板
+  window_state_title: 窗口状态
+  window_state_desc: "在你上次关闭的位置重新打开 Baudrun 和设置窗口。关闭后，每次启动都会以居中的默认尺寸打开。重置按钮会清除已保存的几何信息，并立即调整对应的活动窗口大小。"
+  window_state_toggle: 启动时恢复窗口大小和位置
+  reset_settings_window: 重置设置窗口
+  reset_main_window: 重置主窗口
+  config_dir_title: 配置目录
+  config_dir_desc: "Baudrun 存储配置、主题、皮肤、高亮规则包和 settings.json 的位置。选择其他位置可在多台机器间共享配置（Dropbox、iCloud Drive、dotfile 仓库），或从干净的目录进行测试。将在下次启动时生效。"
+  theme_preview:
+    subtitle_imported: "导入的主题 · 示例输出 · 最后一行显示文本选中效果"
+    subtitle_builtin: "内置主题 · 示例输出 · 最后一行显示文本选中效果"
+  undo: 撤销
+  prompt:
+    choose_config_dir: "选择 Baudrun 配置目录"
+    choose_log_dir: 选择会话日志目录
+    import_skin: "导入皮肤 JSON"
+    import_theme: "导入主题（.itermcolors 或 JSON）"
+    import_pack: "导入高亮规则包 JSON"
+  toast:
+    save_failed: "无法保存设置：%{err}"
+    config_open_failed: "无法打开配置目录：%{err}"
+    config_set: "配置目录已设置。重启 Baudrun 以使用它。"
+    config_set_failed: "无法设置配置目录：%{err}"
+    config_reset: "配置目录已重置。重启 Baudrun 以使用默认值。"
+    config_reset_failed: "无法重置配置目录：%{err}"
+    log_dir_updated: 日志目录已更新
+    log_dir_reset: 日志目录已重置为默认值
+    skin_imported: "已导入皮肤“%{name}”"
+    skin_import_failed: "无法导入皮肤：%{err}"
+    skin_removed: "已移除皮肤“%{name}”"
+    skin_delete_failed: "无法删除皮肤：%{err}"
+    skin_restored: "已恢复皮肤“%{name}”"
+    skin_restore_failed: "无法恢复皮肤：%{err}"
+    theme_imported: "已导入主题“%{name}”"
+    theme_import_failed: "无法导入主题：%{err}"
+    theme_removed: "已移除主题“%{name}”"
+    theme_delete_failed: "无法删除主题：%{err}"
+    theme_restored: "已恢复主题“%{name}”"
+    theme_restore_failed: "无法恢复主题：%{err}"
+    pack_imported: "已导入规则包“%{name}”"
+    pack_import_failed: "无法导入规则包：%{err}"
+    pack_removed: "已移除规则包“%{name}”"
+    pack_delete_failed: "无法删除规则包：%{err}"
+    pack_restored: "已恢复规则包“%{name}”"
+    pack_restore_failed: "无法恢复规则包：%{err}"

--- a/src/app_view/buttons.rs
+++ b/src/app_view/buttons.rs
@@ -49,7 +49,7 @@ pub(super) fn line_pill(s: SkinTokens, label: &'static str, active: bool) -> gpu
 /// red for destructive actions like Delete. Returns a bare `Div`
 /// so the call site can attach `.on_mouse_up` etc. — the helper
 /// just owns the visual styling.
-pub(super) fn pill_button(s: SkinTokens, label: &'static str, danger: bool) -> gpui::Div {
+pub(super) fn pill_button(s: SkinTokens, label: impl IntoElement, danger: bool) -> gpui::Div {
     let fg = if danger {
         rgba(s.danger)
     } else {
@@ -79,7 +79,7 @@ pub(super) fn pill_button(s: SkinTokens, label: &'static str, danger: bool) -> g
 /// Primary action button — solid `--accent` blue, white text. Used
 /// for the form's Connect button (the call-to-action). Same shape
 /// as `pill_button` so they line up flush in a button row.
-pub(super) fn primary_button(s: SkinTokens, label: &'static str) -> gpui::Div {
+pub(super) fn primary_button(s: SkinTokens, label: impl IntoElement) -> gpui::Div {
     div()
         .px_3()
         .py_1()

--- a/src/app_view/chrome.rs
+++ b/src/app_view/chrome.rs
@@ -20,7 +20,7 @@
 //! works without visibility widening — Rust's privacy rule lets
 //! descendant modules see the parent's private items.
 
-use std::time::Duration;
+use std::{borrow::Cow, time::Duration};
 
 use gpui::{
     anchored, deferred, div, prelude::*, pulsating_between, px, rgba, Animation, AnimationExt,
@@ -55,7 +55,7 @@ pub(super) fn profile_context_menu_overlay(
     let item: gpui::Div = if is_connected_row {
         profile_menu_item(
             s,
-            "Move Session to New Window",
+            t!("chrome.move_session_to_new_window"),
             cx.listener(move |this, _: &MouseUpEvent, _window, cx| {
                 this.profile_context_menu = None;
                 this.move_session_to_new_window(None, cx);
@@ -64,7 +64,7 @@ pub(super) fn profile_context_menu_overlay(
     } else {
         profile_menu_item(
             s,
-            "Connect in New Window",
+            t!("chrome.connect_in_new_window"),
             cx.listener(move |this, _: &MouseUpEvent, _window, cx| {
                 let id = profile_id.clone();
                 this.profile_context_menu = None;
@@ -113,7 +113,7 @@ pub(super) fn profile_context_menu_overlay(
 /// gpui-component's PopupMenu (which routes through the Action
 /// system) since we have a single click handler that already needs
 /// the per-row profile id baked in.
-pub(super) fn profile_menu_item<F>(s: SkinTokens, label: &'static str, on_click: F) -> gpui::Div
+pub(super) fn profile_menu_item<F>(s: SkinTokens, label: impl IntoElement, on_click: F) -> gpui::Div
 where
     F: Fn(&MouseUpEvent, &mut Window, &mut gpui::App) + 'static,
 {
@@ -175,13 +175,13 @@ pub(super) fn suspended_banner(s: SkinTokens, _cx: &mut Context<AppView>) -> imp
             div()
                 .text_size(px(12.0))
                 .text_color(rgba(s.fg_primary))
-                .child("Session suspended"),
+                .child(t!("chrome.session_suspended_title")),
         )
         .child(
             div()
                 .text_size(px(11.0))
                 .text_color(rgba(s.fg_secondary))
-                .child("Port still open. Bytes keep flowing into scrollback."),
+                .child(t!("chrome.suspended_banner_detail")),
         )
 }
 
@@ -195,7 +195,7 @@ pub(super) fn suspended_pane(
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     let port_line = if profile.port_name.is_empty() {
-        "(no port)".to_string()
+        t!("chrome.no_port").to_string()
     } else {
         format!("{} @ {}", profile.port_name, profile.baud_rate)
     };
@@ -216,7 +216,7 @@ pub(super) fn suspended_pane(
             div()
                 .text_size(px(11.0))
                 .text_color(rgba(s.fg_tertiary))
-                .child("SESSION SUSPENDED"),
+                .child(t!("chrome.session_suspended_heading")),
         )
         .child(
             div()
@@ -234,9 +234,9 @@ pub(super) fn suspended_pane(
             div()
                 .text_size(px(12.0))
                 .text_color(rgba(s.fg_tertiary))
-                .child("Port stays open; bytes keep flowing into scrollback."),
+                .child(t!("chrome.suspended_pane_detail")),
         )
-        .child(primary_button(s, "Resume").on_mouse_up(
+        .child(primary_button(s, t!("chrome.resume_button")).on_mouse_up(
             MouseButton::Left,
             cx.listener(|this, _: &MouseUpEvent, window, cx| {
                 this.resume_session(window, cx);
@@ -266,7 +266,7 @@ pub(super) fn about_dialog_body() -> impl IntoElement {
             div()
                 .text_sm()
                 .opacity(0.75)
-                .child(format!("Version {version} (prototype)")),
+                .child(t!("chrome.about_version", version = version)),
         )
         .child(
             // Tagline pulls from the same source-of-truth as
@@ -280,7 +280,7 @@ pub(super) fn about_dialog_body() -> impl IntoElement {
             div()
                 .text_sm()
                 .opacity(0.65)
-                .child("© 2025–2026 packetThrower / Baudrun contributors"),
+                .child(t!("chrome.about_copyright")),
         )
         .child(
             div()
@@ -290,7 +290,7 @@ pub(super) fn about_dialog_body() -> impl IntoElement {
                 .cursor_pointer()
                 .hover(|s| s.text_color(gpui::rgba(0x60a5faffu32)))
                 .on_click(|_evt, _window, cx| cx.open_url(GITHUB_URL))
-                .child("View on GitHub"),
+                .child(t!("chrome.view_on_github")),
         )
 }
 
@@ -310,19 +310,15 @@ pub(super) fn friendly_open_error(port: &str, err: &serialport::Error) -> String
             serialport::ErrorKind::Io(std::io::ErrorKind::PermissionDenied)
         ) || base.to_ascii_lowercase().contains("permission denied");
         if is_perm {
-            return format!(
-                "open {port}: {base} — your user can't access this serial port. \
-                 Fix: install Baudrun's udev rule (already done if you used the \
-                 .deb / .rpm / .pkg.tar.zst installer; rerun the installer if it \
-                 didn't take), then unplug + replug the USB adapter. \
-                 As a one-off workaround: `sudo chmod 666 {port}` opens it for \
-                 the current plug-in. The legacy dialout-group flow \
-                 (`sudo usermod -aG dialout $USER` + log out + log in) also \
-                 works."
-            );
+            return t!(
+                "chrome.open_error_permission_linux",
+                port = port,
+                base = base
+            )
+            .to_string();
         }
     }
-    format!("open {port}: {base}")
+    t!("chrome.open_error", port = port, base = base).to_string()
 }
 
 pub(super) fn welcome_pane(s: SkinTokens, has_profiles: bool) -> impl IntoElement {
@@ -392,7 +388,7 @@ pub(super) fn session_header(
         profile.port_name, profile.baud_rate, profile.data_bits, parity_letter, profile.stop_bits,
     );
     if reconnecting {
-        meta.push_str(" · reconnecting…");
+        meta.push_str(&t!("chrome.reconnecting_suffix"));
     }
     let s = *cx.global::<SkinTokens>();
     let dot_color = if reconnecting { s.warn } else { s.success };
@@ -482,9 +478,9 @@ pub(super) fn session_header(
                         .child(line_pill(s, "DTR", dtr_asserted))
                         .tooltip(move |window, cx| {
                             Tooltip::new(SharedString::from(if dtr_asserted {
-                                "DTR is asserted — click to deassert"
+                                t!("chrome.dtr_asserted_tooltip")
                             } else {
-                                "DTR is deasserted — click to assert"
+                                t!("chrome.dtr_deasserted_tooltip")
                             }))
                             .build(window, cx)
                         })
@@ -501,9 +497,9 @@ pub(super) fn session_header(
                         .child(line_pill(s, "RTS", rts_asserted))
                         .tooltip(move |window, cx| {
                             Tooltip::new(SharedString::from(if rts_asserted {
-                                "RTS is asserted — click to deassert"
+                                t!("chrome.rts_asserted_tooltip")
                             } else {
-                                "RTS is deasserted — click to assert"
+                                t!("chrome.rts_deasserted_tooltip")
                             }))
                             .build(window, cx)
                         })
@@ -514,21 +510,21 @@ pub(super) fn session_header(
                             }),
                         ),
                 )
-                .child(pill_button(s, "Clear", false).on_mouse_up(
-                    MouseButton::Left,
-                    cx.listener(|this, _: &MouseUpEvent, _window, cx| {
-                        this.terminal.update(cx, |t, cx| t.clear_screen(cx));
-                    }),
-                ))
+                .child(
+                    pill_button(s, t!("chrome.clear_button"), false).on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, _window, cx| {
+                            this.terminal.update(cx, |t, cx| t.clear_screen(cx));
+                        }),
+                    ),
+                )
                 .child(
                     div()
                         .id("session-suspend")
-                        .child(pill_button(s, "Suspend", false))
+                        .child(pill_button(s, t!("chrome.suspend_button"), false))
                         .tooltip(|window, cx| {
-                            Tooltip::new(SharedString::from(
-                                "Keep session alive; return to profile",
-                            ))
-                            .build(window, cx)
+                            Tooltip::new(SharedString::from(t!("chrome.suspend_tooltip")))
+                                .build(window, cx)
                         })
                         .on_mouse_up(
                             MouseButton::Left,
@@ -537,12 +533,14 @@ pub(super) fn session_header(
                             }),
                         ),
                 )
-                .child(primary_button(s, "Disconnect").on_mouse_up(
-                    MouseButton::Left,
-                    cx.listener(|this, _: &MouseUpEvent, window, cx| {
-                        this.disconnect_current(window, cx);
-                    }),
-                )),
+                .child(
+                    primary_button(s, t!("chrome.disconnect_button")).on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                            this.disconnect_current(window, cx);
+                        }),
+                    ),
+                ),
         )
 }
 
@@ -576,13 +574,20 @@ pub(super) fn status_bar(
         }
         None => {
             let text = match (connected, editing_profile_name) {
-                (Some(p), _) if reconnecting => {
-                    format!("Reconnecting to {} @ {}…", p.port_name, p.baud_rate)
+                (Some(p), _) if reconnecting => t!(
+                    "chrome.reconnecting",
+                    port = p.port_name,
+                    baud = p.baud_rate
+                )
+                .to_string(),
+                (Some(p), _) => {
+                    t!("chrome.connected", port = p.port_name, baud = p.baud_rate).to_string()
                 }
-                (Some(p), _) => format!("Connected to {} @ {}", p.port_name, p.baud_rate),
-                (None, Some(name)) if !name.is_empty() => format!("Editing {name}"),
-                (None, Some(_)) => "Editing new profile".to_string(),
-                (None, None) => "Not connected".to_string(),
+                (None, Some(name)) if !name.is_empty() => {
+                    t!("chrome.editing", name = name).to_string()
+                }
+                (None, Some(_)) => t!("chrome.editing_new").to_string(),
+                (None, None) => t!("chrome.not_connected").to_string(),
             };
             (text, rgba(s.fg_secondary))
         }
@@ -597,20 +602,20 @@ pub(super) fn status_bar(
     // user gets a quick at-a-glance read of which formatters
     // the live byte stream is going through without having to
     // open the profile editor.
-    let (indicators, scrollback_text): (Vec<&'static str>, Option<String>) = match connected {
+    let (indicators, scrollback_text): (Vec<Cow<'static, str>>, Option<String>) = match connected {
         Some(p) => {
-            let mut tags: Vec<&'static str> = Vec::new();
+            let mut tags: Vec<Cow<'static, str>> = Vec::new();
             if p.hex_view {
-                tags.push("HEX");
+                tags.push(t!("chrome.chip_hex"));
             }
             if p.timestamps {
-                tags.push("TIME");
+                tags.push(t!("chrome.chip_time"));
             }
             if p.line_numbers {
-                tags.push("LINE#");
+                tags.push(t!("chrome.chip_line"));
             }
             if p.log_enabled {
-                tags.push("TO FILE");
+                tags.push(t!("chrome.chip_to_file"));
             }
             (
                 tags,
@@ -621,7 +626,7 @@ pub(super) fn status_bar(
     };
     let bg_input = s.bg_input;
     let fg_secondary = s.fg_secondary;
-    let chip = move |label: &'static str| {
+    let chip = move |label: Cow<'static, str>| {
         // Flat pill — no border + no vertical padding so the
         // status bar's overall height stays the same as the
         // text-only baseline. A taller bar steals a row from
@@ -654,7 +659,7 @@ pub(super) fn status_bar(
                 .id("status-scrollback")
                 .child(t)
                 .tooltip(|window, cx| {
-                    Tooltip::new(SharedString::from("Scrollback lines: filled / max"))
+                    Tooltip::new(SharedString::from(t!("chrome.scrollback_tooltip")))
                         .build(window, cx)
                 })
         }))
@@ -677,7 +682,7 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
     // Shared chrome for the inline icon-buttons. Each button needs
     // its own stable id so the tooltip layer can disambiguate hover
     // targets, and a label string for the tooltip itself.
-    let icon_btn = move |id: &'static str, tip: &'static str| {
+    let icon_btn = move |id: &'static str, tip: Cow<'static, str>| {
         let tip_text = SharedString::from(tip);
         div()
             .id(SharedString::from(id))
@@ -709,15 +714,18 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
                     // quotation mark — same chrome-glyph aesthetic
                     // as the other inline buttons (+ / ⧉ / ⚙), so
                     // the four read as one cluster.
-                    icon_btn("nav-collapse-sidebar", "Collapse sidebar")
-                        .text_size(px(15.0))
-                        .child("\u{2039}")
-                        .on_mouse_up(
-                            MouseButton::Left,
-                            cx.listener(|this, _: &MouseUpEvent, _window, cx| {
-                                this.toggle_sidebar(cx);
-                            }),
-                        ),
+                    icon_btn(
+                        "nav-collapse-sidebar",
+                        t!("chrome.collapse_sidebar_tooltip"),
+                    )
+                    .text_size(px(15.0))
+                    .child("\u{2039}")
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, _window, cx| {
+                            this.toggle_sidebar(cx);
+                        }),
+                    ),
                 )
                 .child(
                     // PROFILES header. Font size + weight + text
@@ -731,7 +739,7 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
                         .text_size(px(s.font_size_label_px))
                         .text_color(rgba(s.fg_tertiary))
                         .font_weight(gpui::FontWeight(s.label_weight as f32))
-                        .child(s.label_transform.apply("PROFILES")),
+                        .child(s.label_transform.apply(&t!("chrome.profiles_label"))),
                 ),
         )
         .child(
@@ -741,7 +749,7 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
                 .items_center()
                 .gap_1()
                 .child(
-                    icon_btn("nav-add-profile", "New profile")
+                    icon_btn("nav-add-profile", t!("chrome.new_profile_tooltip"))
                         .text_size(px(16.0))
                         .child("+")
                         .on_mouse_up(
@@ -757,7 +765,7 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
                 // expect Cmd+N can still use it once Phase 8 wires
                 // the application menu.
                 .child(
-                    icon_btn("nav-new-window", "New window")
+                    icon_btn("nav-new-window", t!("chrome.new_window_tooltip"))
                         .text_size(px(15.0))
                         .child("\u{29C9}")
                         .on_mouse_up(
@@ -788,7 +796,7 @@ pub(super) fn sidebar_header(update_pending: bool, cx: &mut Context<AppView>) ->
                     div()
                         .relative()
                         .child(
-                            icon_btn("nav-settings", "Settings")
+                            icon_btn("nav-settings", t!("chrome.settings_tooltip"))
                                 .text_size(px(15.0))
                                 .child("\u{2699}")
                                 .on_mouse_up(
@@ -831,7 +839,7 @@ pub(super) fn sidebar_icon_strip(
     // Same `icon_btn` recipe as `sidebar_header`, but stretched to
     // fill the strip's width so the hover-bg rect reads as a
     // proper button target rather than a small glyph-only chip.
-    let icon_btn = move |id: &'static str, tip: &'static str| {
+    let icon_btn = move |id: &'static str, tip: Cow<'static, str>| {
         let tip_text = SharedString::from(tip);
         div()
             .id(SharedString::from(id))
@@ -855,7 +863,7 @@ pub(super) fn sidebar_icon_strip(
         .child(
             // Expand chevron — `›` (U+203A), mirror of the
             // collapse glyph in `sidebar_header`.
-            icon_btn("nav-expand-sidebar", "Expand sidebar")
+            icon_btn("nav-expand-sidebar", t!("chrome.expand_sidebar_tooltip"))
                 .text_size(px(16.0))
                 .child("\u{203A}")
                 .on_mouse_up(
@@ -866,18 +874,21 @@ pub(super) fn sidebar_icon_strip(
                 ),
         )
         .child(
-            icon_btn("nav-add-profile-collapsed", "New profile")
-                .text_size(px(16.0))
-                .child("+")
-                .on_mouse_up(
-                    MouseButton::Left,
-                    cx.listener(|this, _: &MouseUpEvent, window, cx| {
-                        this.open_editor(window, cx);
-                    }),
-                ),
+            icon_btn(
+                "nav-add-profile-collapsed",
+                t!("chrome.new_profile_tooltip"),
+            )
+            .text_size(px(16.0))
+            .child("+")
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                    this.open_editor(window, cx);
+                }),
+            ),
         )
         .child(
-            icon_btn("nav-new-window-collapsed", "New window")
+            icon_btn("nav-new-window-collapsed", t!("chrome.new_window_tooltip"))
                 .text_size(px(15.0))
                 .child("\u{29C9}")
                 .on_mouse_up(
@@ -897,7 +908,7 @@ pub(super) fn sidebar_icon_strip(
                 .relative()
                 .w_full()
                 .child(
-                    icon_btn("nav-settings-collapsed", "Settings")
+                    icon_btn("nav-settings-collapsed", t!("chrome.settings_tooltip"))
                         .text_size(px(15.0))
                         .child("\u{2699}")
                         .on_mouse_up(
@@ -975,28 +986,28 @@ pub(super) fn session_overflow_button(
                             .py_1()
                             .child(profile_menu_item(
                                 s,
-                                "Send Break",
+                                t!("chrome.send_break"),
                                 cx.listener(|this, _: &MouseUpEvent, window, cx| {
                                     this.send_break_now(window, cx);
                                 }),
                             ))
                             .child(profile_menu_item(
                                 s,
-                                "Send Hex\u{2026}",
+                                t!("chrome.send_hex"),
                                 cx.listener(|this, _: &MouseUpEvent, window, cx| {
                                     this.open_send_hex(window, cx);
                                 }),
                             ))
                             .child(profile_menu_item(
                                 s,
-                                "Send File\u{2026}",
+                                t!("chrome.send_file"),
                                 cx.listener(|this, _: &MouseUpEvent, window, cx| {
                                     this.start_send_file(window, cx);
                                 }),
                             ))
                             .child(profile_menu_item(
                                 s,
-                                "Move to New Window",
+                                t!("chrome.move_to_new_window"),
                                 cx.listener(|this, _: &MouseUpEvent, _window, cx| {
                                     this.move_session_to_new_window(None, cx);
                                 }),
@@ -1024,7 +1035,7 @@ pub(super) fn session_overflow_button(
                 .cursor_pointer()
                 .hover(move |st| st.bg(rgba(s.bg_hover)))
                 .tooltip(|window, cx| {
-                    Tooltip::new(SharedString::from("More actions")).build(window, cx)
+                    Tooltip::new(SharedString::from(t!("chrome.more_actions"))).build(window, cx)
                 })
                 .child("\u{22EF}")
                 .on_mouse_up(

--- a/src/app_view/chrome.rs
+++ b/src/app_view/chrome.rs
@@ -327,9 +327,9 @@ pub(super) fn friendly_open_error(port: &str, err: &serialport::Error) -> String
 
 pub(super) fn welcome_pane(s: SkinTokens, has_profiles: bool) -> impl IntoElement {
     let prompt = if has_profiles {
-        "Pick a profile from the sidebar to start a session."
+        t!("welcome.pick_profile")
     } else {
-        "Click the + above the profile list to create one."
+        t!("welcome.create_first")
     };
     // Paint `bg_main` here only when the AppView right-pane
     // wrapper isn't already doing so. Floating-card skins
@@ -353,7 +353,7 @@ pub(super) fn welcome_pane(s: SkinTokens, has_profiles: bool) -> impl IntoElemen
             div()
                 .text_size(px(s.font_size_h1_px))
                 .text_color(rgba(s.fg_primary))
-                .child("Baudrun"),
+                .child(t!("welcome.heading")),
         )
         .child(
             div()

--- a/src/app_view/editor.rs
+++ b/src/app_view/editor.rs
@@ -67,7 +67,7 @@ pub(super) fn build_editor(
         let val = profile.name.clone();
         cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("My switch")
+                .placeholder(t!("editor.name_placeholder"))
                 .default_value(val)
         })
     };
@@ -83,10 +83,10 @@ pub(super) fn build_editor(
     // settings.default_theme_id.
     let theme = {
         let mut opts = Vec::with_capacity(themes_store.list().len() + 1);
-        opts.push(Opt::new("", "Use global default"));
+        opts.push(Opt::new("", &t!("editor.theme.use_global_default")));
         for t in themes_store.list() {
             let title = if t.source == "user" {
-                format!("{} (custom)", t.name)
+                t!("editor.custom_suffix", name = t.name).into_owned()
             } else {
                 t.name
             };
@@ -406,9 +406,9 @@ fn form_header(
 ) -> impl IntoElement {
     let s = *cx.global::<SkinTokens>();
     let subtitle = if is_edit {
-        "EDIT PROFILE"
+        t!("editor.subtitle_edit")
     } else {
-        "NEW PROFILE"
+        t!("editor.subtitle_new")
     };
     // Save button text-color is the only thing that changes for the
     // dirty state — pill bg stays the same so the button doesn't
@@ -421,7 +421,7 @@ fn form_header(
         rgba(s.fg_tertiary)
     };
     let delete_btn = is_edit.then(|| {
-        pill_button(s, "Delete", true).on_mouse_up(
+        pill_button(s, t!("editor.delete_button"), true).on_mouse_up(
             MouseButton::Left,
             cx.listener(|this, _: &MouseUpEvent, window, cx| {
                 this.delete_from_editor(window, cx);
@@ -436,7 +436,7 @@ fn form_header(
     // field at the top of the Connection card now.
     let title_text = name.read(cx).value().to_string();
     let title_text = if title_text.is_empty() {
-        "(unnamed)".to_string()
+        t!("editor.unnamed_title").to_string()
     } else {
         title_text
     };
@@ -477,7 +477,7 @@ fn form_header(
                 .gap_2()
                 .children(delete_btn)
                 .child(
-                    pill_button(s, "Save", false)
+                    pill_button(s, t!("editor.save_button"), false)
                         .text_color(save_fg)
                         .on_mouse_up(
                             MouseButton::Left,
@@ -486,12 +486,14 @@ fn form_header(
                             }),
                         ),
                 )
-                .child(pill_button(s, "Cancel", false).on_mouse_up(
-                    MouseButton::Left,
-                    cx.listener(|this, _: &MouseUpEvent, _window, cx| {
-                        this.cancel_editor(cx);
-                    }),
-                ))
+                .child(
+                    pill_button(s, t!("editor.cancel_button"), false).on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, _window, cx| {
+                            this.cancel_editor(cx);
+                        }),
+                    ),
+                )
                 .when(connected_session, |row| {
                     // Suspended on the connected profile — swap the
                     // Connect button for the Disconnect + Resume
@@ -500,21 +502,25 @@ fn form_header(
                     // race for its own port or re-open a session
                     // the user already has, neither of which is
                     // what they're after.
-                    row.child(pill_button(s, "Disconnect", false).on_mouse_up(
-                        MouseButton::Left,
-                        cx.listener(|this, _: &MouseUpEvent, window, cx| {
-                            this.disconnect_current(window, cx);
-                        }),
-                    ))
-                    .child(primary_button(s, "Resume").on_mouse_up(
-                        MouseButton::Left,
-                        cx.listener(|this, _: &MouseUpEvent, window, cx| {
-                            this.resume_session(window, cx);
-                        }),
-                    ))
+                    row.child(
+                        pill_button(s, t!("editor.disconnect_button"), false).on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                                this.disconnect_current(window, cx);
+                            }),
+                        ),
+                    )
+                    .child(
+                        primary_button(s, t!("editor.resume_button")).on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                                this.resume_session(window, cx);
+                            }),
+                        ),
+                    )
                 })
                 .when(!connected_session, |row| {
-                    row.child(primary_button(s, "Connect").on_mouse_up(
+                    row.child(primary_button(s, t!("editor.connect_button")).on_mouse_up(
                         MouseButton::Left,
                         cx.listener(|this, _: &MouseUpEvent, window, cx| {
                             this.save_and_connect(window, cx);
@@ -650,7 +656,7 @@ fn form_body(
 /// selected state reads instantly.
 fn form_tab_nav(active: EditorTab, cx: &mut Context<AppView>) -> impl IntoElement {
     let s = *cx.global::<SkinTokens>();
-    let item = move |label: &'static str, tab: EditorTab| {
+    let item = move |id: &'static str, label: SharedString, tab: EditorTab| {
         let is_active = tab == active;
         let bg = if is_active {
             rgba(s.bg_active)
@@ -671,7 +677,7 @@ fn form_tab_nav(active: EditorTab, cx: &mut Context<AppView>) -> impl IntoElemen
             // without it the `.hover()` style only paints when some
             // unrelated event happens to dirty AppView. Same fix as
             // `profile_row`. Labels here are unique within the rail.
-            .id(label)
+            .id(id)
             .w_full()
             .px_3()
             .py(px(6.0))
@@ -704,9 +710,21 @@ fn form_tab_nav(active: EditorTab, cx: &mut Context<AppView>) -> impl IntoElemen
         .flex_col()
         .gap_1()
         .text_size(px(13.0))
-        .child(item("Connection", EditorTab::Connection))
-        .child(item("Highlighting", EditorTab::Highlighting))
-        .child(item("Advanced", EditorTab::Advanced))
+        .child(item(
+            "Connection",
+            t!("editor.tab.connection").into(),
+            EditorTab::Connection,
+        ))
+        .child(item(
+            "Highlighting",
+            t!("editor.tab.highlighting").into(),
+            EditorTab::Highlighting,
+        ))
+        .child(item(
+            "Advanced",
+            t!("editor.tab.advanced").into(),
+            EditorTab::Advanced,
+        ))
 }
 
 /// One section of the form — a translucent panel with a heading,
@@ -714,16 +732,21 @@ fn form_tab_nav(active: EditorTab, cx: &mut Context<AppView>) -> impl IntoElemen
 /// `--font-size-section` (15px); description is the muted
 /// `--fg-secondary`. Panel uses `--radius-lg` (10px) and
 /// `--bg-panel` / `--border-subtle`.
-fn section_card(s: SkinTokens, title: &'static str, body: impl IntoElement) -> gpui::Div {
+fn section_card(
+    s: SkinTokens,
+    title: impl Into<SharedString>,
+    body: impl IntoElement,
+) -> gpui::Div {
     section_card_with_desc(s, title, None, body)
 }
 
 fn section_card_with_desc(
     s: SkinTokens,
-    title: &'static str,
-    description: Option<&'static str>,
+    title: impl Into<SharedString>,
+    description: Option<SharedString>,
     body: impl IntoElement,
 ) -> gpui::Div {
+    let title: SharedString = title.into();
     let mut header = div().flex().flex_col().gap_1().child(
         div()
             .text_size(px(s.font_size_section_px))
@@ -784,7 +807,8 @@ fn section_card_with_desc(
 /// Label is `whitespace_nowrap` because gpui defaults to wrap, and
 /// short fixed strings like "SLOW-PASTE DELAY (MS)" wrapping mid-
 /// label inside a narrow container looks broken.
-fn labeled(s: SkinTokens, label: &'static str, widget: impl IntoElement) -> gpui::Div {
+fn labeled(s: SkinTokens, label: impl Into<SharedString>, widget: impl IntoElement) -> gpui::Div {
+    let label: SharedString = label.into();
     div()
         .flex()
         .flex_col()
@@ -840,13 +864,16 @@ fn driver_banner_row(
     } else if !candidate.manufacturer.is_empty() {
         candidate.manufacturer.clone()
     } else {
-        "USB device".to_string()
+        t!("editor.driver.usb_device").to_string()
     };
     if !candidate.serial_number.is_empty() {
-        meta.push_str(" \u{00B7} serial ");
+        meta.push_str(&t!("editor.driver.serial_prefix"));
         meta.push_str(&candidate.serial_number);
     }
-    let title = format!("{} detected \u{2014} driver not loaded", candidate.chipset);
+    let title = t!(
+        "editor.driver.not_loaded_title",
+        chipset = candidate.chipset
+    );
 
     let mut text_col = div().flex_1().min_w_0().flex().flex_col().gap_1().child(
         div()
@@ -899,12 +926,14 @@ fn driver_banner_row(
         .child(text_col);
     if !candidate.driver_url.is_empty() {
         let url = candidate.driver_url.clone();
-        row = row.child(pill_button(s, "Install driver\u{2026}", false).on_mouse_up(
-            MouseButton::Left,
-            cx.listener(move |_, _: &MouseUpEvent, _, cx| {
-                cx.open_url(&url);
-            }),
-        ));
+        row = row.child(
+            pill_button(s, t!("editor.driver.install_button"), false).on_mouse_up(
+                MouseButton::Left,
+                cx.listener(move |_, _: &MouseUpEvent, _, cx| {
+                    cx.open_url(&url);
+                }),
+            ),
+        );
     }
     row
 }
@@ -934,12 +963,11 @@ fn connection_card(
         .flex_row()
         .items_end()
         .gap_2()
-        .child(
-            div()
-                .flex_1()
-                .min_w_0()
-                .child(labeled(s, "SERIAL PORT", Select::new(&port))),
-        )
+        .child(div().flex_1().min_w_0().child(labeled(
+            s,
+            t!("editor.field.serial_port"),
+            Select::new(&port),
+        )))
         .child(
             div()
                 // Stable id so gpui notifies on hover transitions —
@@ -973,7 +1001,11 @@ fn connection_card(
         .flex()
         .flex_col()
         .gap_3()
-        .child(labeled(s, "NAME", Input::new(&name).appearance(true)))
+        .child(labeled(
+            s,
+            t!("editor.field.name"),
+            Input::new(&name).appearance(true),
+        ))
         .when(!driver_banners.is_empty(), |this| {
             this.child(div().flex().flex_col().gap_2().children(driver_banners))
         })
@@ -984,35 +1016,39 @@ fn connection_card(
                 .flex()
                 .flex_row()
                 .gap_3()
-                .child(
-                    div()
-                        .flex_1()
-                        .child(labeled(s, "BAUD RATE", Select::new(&baud))),
-                )
-                .child(
-                    div()
-                        .flex_1()
-                        .child(labeled(s, "DATA BITS", Select::new(&data_bits))),
-                ),
+                .child(div().flex_1().child(labeled(
+                    s,
+                    t!("editor.field.baud_rate"),
+                    Select::new(&baud),
+                )))
+                .child(div().flex_1().child(labeled(
+                    s,
+                    t!("editor.field.data_bits"),
+                    Select::new(&data_bits),
+                ))),
         )
         .child(
             div()
                 .flex()
                 .flex_row()
                 .gap_3()
-                .child(
-                    div()
-                        .flex_1()
-                        .child(labeled(s, "PARITY", Select::new(&parity))),
-                )
-                .child(
-                    div()
-                        .flex_1()
-                        .child(labeled(s, "STOP BITS", Select::new(&stop_bits))),
-                ),
+                .child(div().flex_1().child(labeled(
+                    s,
+                    t!("editor.field.parity"),
+                    Select::new(&parity),
+                )))
+                .child(div().flex_1().child(labeled(
+                    s,
+                    t!("editor.field.stop_bits"),
+                    Select::new(&stop_bits),
+                ))),
         )
-        .child(labeled(s, "FLOW CONTROL", Select::new(&flow_control)));
-    section_card(s, "Connection", body)
+        .child(labeled(
+            s,
+            t!("editor.field.flow_control"),
+            Select::new(&flow_control),
+        ));
+    section_card(s, t!("editor.tab.connection"), body)
 }
 
 fn terminal_card(
@@ -1033,23 +1069,23 @@ fn terminal_card(
                 .gap_3()
                 .child(div().flex_1().child(labeled(
                     s,
-                    "SEND LINE ENDING",
+                    t!("editor.field.send_line_ending"),
                     Select::new(&line_ending),
                 )))
                 .child(div().flex_1().child(labeled(
                     s,
-                    "BACKSPACE SENDS",
+                    t!("editor.field.backspace_sends"),
                     Select::new(&backspace_key),
                 ))),
         )
         .child(bool_field(
             "local-echo",
-            "Local echo",
+            t!("editor.field.local_echo"),
             local_echo,
             cx,
             |ed, v| ed.local_echo = v,
         ));
-    section_card(s, "Terminal", body)
+    section_card(s, t!("editor.section.terminal"), body)
 }
 
 /// Generic checkbox row that writes back to the open editor when
@@ -1058,7 +1094,7 @@ fn terminal_card(
 /// name as a string would force runtime dispatch for no benefit.
 fn bool_field<F>(
     id: &'static str,
-    label: &'static str,
+    label: impl Into<SharedString>,
     checked: bool,
     cx: &mut Context<AppView>,
     set: F,
@@ -1074,8 +1110,8 @@ where
 /// view ┄ show incoming bytes as hex dump" pattern.
 fn bool_field_hinted<F>(
     id: &'static str,
-    label: &'static str,
-    hint: Option<&'static str>,
+    label: impl Into<SharedString>,
+    hint: Option<SharedString>,
     checked: bool,
     cx: &mut Context<AppView>,
     set: F,
@@ -1086,7 +1122,7 @@ where
     let s = *cx.global::<SkinTokens>();
     let cb = Checkbox::new(id)
         .checked(checked)
-        .label(label)
+        .label(label.into())
         .on_click(cx.listener(move |this, checked: &bool, _window, cx| {
             if let Some(ed) = this.editor.as_mut() {
                 set(ed, *checked);
@@ -1137,7 +1173,7 @@ fn highlighting_pane(
             let cb_id = SharedString::from(format!("profile-highlight-{}", p.id));
             let is_on = effective.iter().any(|e| e == &p.id);
             let label = if p.source == "user" || p.source == "import" {
-                format!("{} (custom)", p.name)
+                t!("editor.custom_suffix", name = p.name).into_owned()
             } else {
                 p.name.clone()
             };
@@ -1166,15 +1202,11 @@ fn highlighting_pane(
 
     let master_card = section_card_with_desc(
         s,
-        "Highlighting",
-        Some(
-            "Master switch for this profile. When off, incoming \
-             output is rendered without any rule-based colouring \
-             regardless of which packs are enabled below.",
-        ),
+        t!("editor.tab.highlighting"),
+        Some(t!("editor.highlight.master_desc").into()),
         bool_field(
             "profile-highlight-master",
-            "Highlight terminal output for this profile",
+            t!("editor.highlight.master_toggle"),
             highlight,
             cx,
             |ed, on| ed.highlight = on,
@@ -1189,7 +1221,7 @@ fn highlighting_pane(
         Checkbox::new("profile-highlight-override")
             .checked(override_packs)
             .disabled(!highlight)
-            .label("Override global pack selection")
+            .label(SharedString::from(t!("editor.highlight.override_toggle")))
             .on_click(cx.listener(|this, checked: &bool, _, cx| {
                 this.set_editor_override_highlight(*checked, cx);
             })),
@@ -1197,12 +1229,8 @@ fn highlighting_pane(
 
     let packs_card = section_card_with_desc(
         s,
-        "Highlight Packs",
-        Some(
-            "Inherit the global selection from Settings, or override \
-             it for this profile. With override off, the rows show \
-             what the global is currently broadcasting (read-only).",
-        ),
+        t!("editor.highlight.packs_title"),
+        Some(t!("editor.highlight.packs_desc").into()),
         div()
             .flex()
             .flex_col()
@@ -1252,14 +1280,14 @@ fn advanced_pane(
                     div()
                         .text_size(px(18.0))
                         .text_color(rgba(s.fg_primary))
-                        .child("Advanced"),
+                        .child(t!("editor.tab.advanced")),
                 )
                 .child(
                     div()
                         .text_size(px(12.0))
                         .text_color(rgba(s.fg_secondary))
                         .whitespace_normal()
-                        .child("Control lines, hex view, timestamps, session logging."),
+                        .child(t!("editor.advanced_desc")),
                 ),
         )
         .child(control_lines_card(
@@ -1294,14 +1322,8 @@ fn advanced_pane(
 fn theme_card(s: SkinTokens, theme: Entity<SelectState<Vec<Opt>>>) -> gpui::Div {
     section_card_with_desc(
         s,
-        "Terminal Theme",
-        Some(
-            "Override the global default theme just for this profile. \
-             Useful for keeping different palettes on different \
-             devices (e.g. red-tinged for production routers, calm \
-             green for the lab switch). Leave on \"Use global \
-             default\" to inherit from Settings \u{2192} Themes.",
-        ),
+        t!("editor.theme.title"),
+        Some(t!("editor.theme.desc").into()),
         Select::new(&theme),
     )
 }
@@ -1326,24 +1348,21 @@ fn control_lines_card(
         .flex_col()
         .gap_3()
         .child(row(
-            "DTR ON CONNECT",
+            t!("editor.field.dtr_on_connect"),
             Select::new(&dtr_on_connect),
-            "RTS ON CONNECT",
+            t!("editor.field.rts_on_connect"),
             Select::new(&rts_on_connect),
         ))
         .child(row(
-            "DTR ON DISCONNECT",
+            t!("editor.field.dtr_on_disconnect"),
             Select::new(&dtr_on_disconnect),
-            "RTS ON DISCONNECT",
+            t!("editor.field.rts_on_disconnect"),
             Select::new(&rts_on_disconnect),
         ));
     section_card_with_desc(
         s,
-        "Control Lines",
-        Some(
-            "Only needed for specific adapters or devices (RS-485 direction, \
-             Arduino DTR-reset, firmwares that key off DTR for session lifecycle).",
-        ),
+        t!("editor.section.control_lines"),
+        Some(t!("editor.control_lines_desc").into()),
         body,
     )
 }
@@ -1368,45 +1387,45 @@ fn output_card(
         .gap_2()
         .child(bool_field_hinted(
             "timestamps",
-            "Line timestamps",
-            Some("prefix each line with wall-clock time"),
+            t!("editor.output.timestamps"),
+            Some(t!("editor.output.timestamps_hint").into()),
             timestamps,
             cx,
             |ed, v| ed.timestamps = v,
         ))
         .child(bool_field_hinted(
             "line-numbers",
-            "Line numbers",
-            Some("prefix each line with a session-local counter (resets on reconnect)"),
+            t!("editor.output.line_numbers"),
+            Some(t!("editor.output.line_numbers_hint").into()),
             line_numbers,
             cx,
             |ed, v| ed.line_numbers = v,
         ))
         .child(bool_field_hinted(
             "hex-view",
-            "Hex view",
-            Some("show incoming bytes as hex dump"),
+            t!("editor.output.hex_view"),
+            Some(t!("editor.output.hex_view_hint").into()),
             hex_view,
             cx,
             |ed, v| ed.hex_view = v,
         ))
         .child(bool_field_hinted(
             "log-enabled",
-            "Record session to file",
-            Some("raw bytes; destination set in Settings → Advanced"),
+            t!("editor.output.log_enabled"),
+            Some(t!("editor.output.log_enabled_hint").into()),
             log_enabled,
             cx,
             |ed, v| ed.log_enabled = v,
         ))
         .child(bool_field_hinted(
             "auto-reconnect",
-            "Auto-reconnect on drop",
-            Some("poll for the port to reappear (up to 30s) and reopen transparently"),
+            t!("editor.output.auto_reconnect"),
+            Some(t!("editor.output.auto_reconnect_hint").into()),
             auto_reconnect,
             cx,
             |ed, v| ed.auto_reconnect = v,
         ));
-    section_card(s, "Output", body)
+    section_card(s, t!("editor.section.output"), body)
 }
 
 fn paste_safety_card(
@@ -1428,32 +1447,29 @@ fn paste_safety_card(
         .gap_2()
         .child(bool_field_hinted(
             "paste-warn",
-            "Confirm multi-line pastes",
-            Some("prompt before sending pasted text that contains line breaks"),
+            t!("editor.paste.warn_multiline"),
+            Some(t!("editor.paste.warn_multiline_hint").into()),
             paste_warn_multiline,
             cx,
             |ed, v| ed.paste_warn_multiline = v,
         ))
         .child(bool_field_hinted(
             "paste-slow",
-            "Slow paste",
-            Some("send one char at a time with a delay"),
+            t!("editor.paste.slow"),
+            Some(t!("editor.paste.slow_hint").into()),
             paste_slow,
             cx,
             |ed, v| ed.paste_slow = v,
         ))
         .child(div().pl_6().w(px(160.0)).child(labeled(
             s,
-            "SLOW-PASTE DELAY (MS)",
+            t!("editor.field.slow_paste_delay"),
             Input::new(&paste_char_delay_ms).small().appearance(true),
         )));
     section_card_with_desc(
         s,
-        "Paste safety",
-        Some(
-            "Catch the \"I pasted into the wrong window\" mistake, and pace pastes so \
-             UARTs on slower devices don't drop bytes.",
-        ),
+        t!("editor.section.paste_safety"),
+        Some(t!("editor.paste.safety_desc").into()),
         body,
     )
 }

--- a/src/app_view/mod.rs
+++ b/src/app_view/mod.rs
@@ -74,7 +74,10 @@ use chrome::{
     sidebar_header, sidebar_icon_strip, status_bar, suspended_banner, suspended_pane, welcome_pane,
 };
 use editor::{apply_editor_to_profile, build_editor, form_pane, EditorRender};
-use opts::{make_select, port_opts, read_select, Opt};
+use opts::{
+    backspace_opts, baud_opts, flow_control_opts, line_ending_opts, line_policy_opts, make_select,
+    parity_opts, port_opts, read_select, Opt,
+};
 use session::{bounds_to_geometry, geometry_to_bounds};
 pub use session::{SessionBundle, WindowInit};
 use transfer_ui::{
@@ -279,6 +282,13 @@ pub struct AppView {
     /// per field so the Input widgets persist their text + cursor
     /// across re-renders without us mirroring it into AppView.
     editor: Option<Editor>,
+    /// Locale the open editor's `Select` option labels were built in.
+    /// Editor dropdowns (baud / parity / line ending / …) bake their
+    /// `t!()` titles into the `SelectState` at construction, so a live
+    /// language switch needs `render` to re-feed translated options
+    /// via `set_items`. Same mechanism SettingsView uses for its
+    /// Appearance / Language pickers. See `relabel_editor_selects`.
+    built_locale: String,
     /// `true` while the connected session is suspended — the port +
     /// OS threads stay alive (bytes still flow into TerminalView's
     /// scrollback), but the terminal viewport is hidden so the
@@ -607,6 +617,7 @@ impl AppView {
             auto_reconnect_for: None,
             last_highlight_sig: None,
             editor: None,
+            built_locale: gpui_component::locale().to_string(),
             suspended: false,
             // Default to "both asserted" — matches the OS / serialport-rs
             // defaults on Unix and Windows. The connect_to path overrides
@@ -651,6 +662,91 @@ impl AppView {
     /// src/i18n.rs + issue #72.
     fn apply_locale(&self, settings: &settings::Settings) {
         gpui_component::set_locale(crate::i18n::resolve(&settings.locale));
+    }
+
+    /// Re-feed translated option labels to the open editor's selects
+    /// after a live language switch. Their `Opt` titles come from
+    /// `t!()` (via the `*_opts()` builders + the theme list) and are
+    /// captured in each `SelectState` at build time, so a plain
+    /// re-render keeps the old-language labels. Current selection is
+    /// preserved. No-op when the editor is closed. `data_bits` /
+    /// `stop_bits` are skipped — their options are bare numbers with
+    /// no translatable text. Called from `render` (which has the
+    /// `Window` `set_items` needs) when the locale changed.
+    fn relabel_editor_selects(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // One relabel job: (select handle, freshly-translated options,
+        // value to reselect).
+        type Relabel = (Entity<SelectState<Vec<Opt>>>, Vec<Opt>, String);
+        // Snapshot handles + freshly-translated options + current
+        // selections in one immutable-borrow scope, then apply. This
+        // drops the `&self.editor` / `&self.themes_store` borrows
+        // before the `set_items` updates take `&mut` through cx.
+        let items: Vec<Relabel> = {
+            let Some(ed) = self.editor.as_ref() else {
+                return;
+            };
+            let mut theme_opts = vec![Opt::new("", &t!("editor.theme.use_global_default"))];
+            for t in self.themes_store.list() {
+                let title = if t.source == "user" {
+                    t!("editor.custom_suffix", name = t.name).into_owned()
+                } else {
+                    t.name
+                };
+                theme_opts.push(Opt::new(&t.id, &title));
+            }
+            let port_cur = read_select(&ed.port, cx);
+            vec![
+                (ed.baud.clone(), baud_opts(), read_select(&ed.baud, cx)),
+                (
+                    ed.parity.clone(),
+                    parity_opts(),
+                    read_select(&ed.parity, cx),
+                ),
+                (
+                    ed.flow_control.clone(),
+                    flow_control_opts(),
+                    read_select(&ed.flow_control, cx),
+                ),
+                (
+                    ed.line_ending.clone(),
+                    line_ending_opts(),
+                    read_select(&ed.line_ending, cx),
+                ),
+                (
+                    ed.backspace_key.clone(),
+                    backspace_opts(),
+                    read_select(&ed.backspace_key, cx),
+                ),
+                (
+                    ed.dtr_on_connect.clone(),
+                    line_policy_opts(),
+                    read_select(&ed.dtr_on_connect, cx),
+                ),
+                (
+                    ed.rts_on_connect.clone(),
+                    line_policy_opts(),
+                    read_select(&ed.rts_on_connect, cx),
+                ),
+                (
+                    ed.dtr_on_disconnect.clone(),
+                    line_policy_opts(),
+                    read_select(&ed.dtr_on_disconnect, cx),
+                ),
+                (
+                    ed.rts_on_disconnect.clone(),
+                    line_policy_opts(),
+                    read_select(&ed.rts_on_disconnect, cx),
+                ),
+                (ed.port.clone(), port_opts(&port_cur), port_cur),
+                (ed.theme.clone(), theme_opts, read_select(&ed.theme, cx)),
+            ]
+        };
+        for (select, opts, current) in items {
+            select.update(cx, |state, cx| {
+                state.set_items(opts, window, cx);
+                state.set_selected_value(&current, window, cx);
+            });
+        }
     }
 
     /// Mirror the global `copy_on_select` flag into the live
@@ -3227,6 +3323,17 @@ impl AppView {
 
 impl Render for AppView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // Live language switch: re-feed translated options to the open
+        // editor's dropdowns before building the tree. Guarded on the
+        // active global locale so it fires once per change, not every
+        // frame (and no-ops when no editor is open). The rest of the
+        // main window's strings are read fresh from `t!()` each render,
+        // so they follow automatically.
+        let active_locale = gpui_component::locale().to_string();
+        if self.built_locale != active_locale {
+            self.built_locale = active_locale;
+            self.relabel_editor_selects(window, cx);
+        }
         let s = *cx.global::<SkinTokens>();
         // `--shadow-panel` from the active skin. Cloned out of
         // the global once per render so both the sidebar + the

--- a/src/app_view/mod.rs
+++ b/src/app_view/mod.rs
@@ -1108,8 +1108,8 @@ impl AppView {
 
         let port = profile.port_name.clone();
         if port.is_empty() {
-            let msg = "profile has no port set";
-            self.connect_error = Some(msg.into());
+            let msg = t!("app.no_port_set");
+            self.connect_error = Some(msg.to_string());
             self.log_event(msg, LogSeverity::Error, cx);
             return;
         }
@@ -1154,7 +1154,7 @@ impl AppView {
                 None => {
                     let msg = last_err
                         .map(|e| friendly_open_error(&port, &e))
-                        .unwrap_or_else(|| format!("open {port}: unknown"));
+                        .unwrap_or_else(|| t!("app.open_unknown", port = port).to_string());
                     self.connect_error = Some(msg.clone());
                     self.log_event(msg, LogSeverity::Error, cx);
                     return;
@@ -1222,7 +1222,7 @@ impl AppView {
             match open_session_log(&profile) {
                 Ok((file, path)) => {
                     self.log_event(
-                        format!("Session log: {}", path.display()),
+                        t!("app.session_log", path = path.display()),
                         LogSeverity::Info,
                         cx,
                     );
@@ -1230,7 +1230,7 @@ impl AppView {
                 }
                 Err(e) => {
                     self.log_event(
-                        format!("Session log open failed: {e}"),
+                        t!("app.session_log_open_failed", error = e),
                         LogSeverity::Error,
                         cx,
                     );
@@ -1304,9 +1304,9 @@ impl AppView {
         // wants confirmation the session came back.
         let was_reconnecting = self.auto_reconnect_for.is_some();
         let connect_message = if was_reconnecting {
-            "Reconnected".to_string()
+            t!("app.reconnected")
         } else {
-            format!("Connected to {port} @ {baud}")
+            t!("app.connected", port = port, baud = baud)
         };
         self.connected_profile_id = Some(profile.id);
         // A successful (re)connect ends any auto-reconnect window —
@@ -1399,7 +1399,7 @@ impl AppView {
 
         let Some(profile) = self.profile_store.get(&id) else {
             self.log_event(
-                format!("session dropped (profile {id} no longer exists)"),
+                t!("app.session_dropped_profile_gone", id = id),
                 LogSeverity::Warn,
                 cx,
             );
@@ -1408,7 +1408,7 @@ impl AppView {
         };
         if !profile.auto_reconnect {
             self.log_event(
-                "Session dropped (auto-reconnect off)",
+                t!("app.session_dropped_no_reconnect"),
                 LogSeverity::Warn,
                 cx,
             );
@@ -1416,7 +1416,7 @@ impl AppView {
             return;
         }
         self.log_event(
-            "Session dropped — auto-reconnecting…",
+            t!("app.session_dropped_reconnecting"),
             LogSeverity::Warn,
             cx,
         );
@@ -1466,7 +1466,7 @@ impl AppView {
                 // trying.
                 app.auto_reconnect_for = None;
                 app.log_event(
-                    format!("Auto-reconnect to {port_name} gave up after 15 attempts"),
+                    t!("app.auto_reconnect_gave_up", port = port_name),
                     LogSeverity::Warn,
                     cx,
                 );
@@ -1518,7 +1518,7 @@ impl AppView {
             d.shutdown();
         }
         self.open_editor_for(id, window, cx);
-        self.log_event("Disconnected", LogSeverity::Info, cx);
+        self.log_event(t!("app.disconnected"), LogSeverity::Info, cx);
     }
 
     /// Switch the active sub-tab on the open editor. No-op if the
@@ -1620,7 +1620,7 @@ impl AppView {
                 Some(p) => p,
                 None => {
                     if let Some(ed) = self.editor.as_mut() {
-                        ed.error = Some("profile no longer exists".into());
+                        ed.error = Some(t!("app.profile_gone").to_string());
                     }
                     cx.notify();
                     return None;
@@ -1692,7 +1692,7 @@ impl AppView {
                 }
                 cx.notify();
                 self.signal_profiles_changed(cx);
-                self.log_event("Saved", LogSeverity::Info, cx);
+                self.log_event(t!("app.saved"), LogSeverity::Info, cx);
                 Some(id)
             }
             Err(e) => {
@@ -1701,7 +1701,7 @@ impl AppView {
                     ed.error = Some(msg.clone());
                 }
                 cx.notify();
-                self.log_event(format!("Save failed: {msg}"), LogSeverity::Error, cx);
+                self.log_event(t!("app.save_failed", error = msg), LogSeverity::Error, cx);
                 None
             }
         }
@@ -1720,8 +1720,8 @@ impl AppView {
             return;
         };
         let Some(profile) = self.profile_store.get(&id) else {
-            let msg = "profile not found";
-            self.connect_error = Some(msg.into());
+            let msg = t!("app.profile_not_found");
+            self.connect_error = Some(msg.to_string());
             self.log_event(msg, LogSeverity::Error, cx);
             cx.notify();
             return;
@@ -1796,15 +1796,17 @@ impl AppView {
                     let app = cx.entity();
                     let name = snapshot.name.clone();
                     window.push_notification(
-                        Notification::success(SharedString::from(format!(
-                            "Removed profile \u{201C}{name}\u{201D}"
+                        Notification::success(SharedString::from(t!(
+                            "app.removed_profile",
+                            name = name
                         )))
                         .action(move |_, _, ctx| {
                             let app = app.clone();
                             let snapshot = snapshot.clone();
                             let notif = ctx.entity();
-                            Button::new("undo-profile-delete").label("Undo").on_click(
-                                move |_, _window, cx| {
+                            Button::new("undo-profile-delete")
+                                .label(t!("app.undo"))
+                                .on_click(move |_, _window, cx| {
                                     let app = app.clone();
                                     let snapshot = snapshot.clone();
                                     let notif = notif.clone();
@@ -1812,8 +1814,7 @@ impl AppView {
                                         this.restore_profile(snapshot, was_selected, view_cx);
                                     });
                                     dismiss_notification_after(notif, cx);
-                                },
-                            )
+                                })
                         })
                         // See settings_view's matching comment: the
                         // .action() builder defaults autohide to false;
@@ -1851,7 +1852,7 @@ impl AppView {
     fn reorder_profile(&mut self, id: String, before: Option<String>, cx: &mut Context<Self>) {
         if let Err(err) = self.profile_store.reorder(&id, before.as_deref()) {
             self.log_event(
-                format!("Couldn't reorder profile: {err}"),
+                t!("app.reorder_failed", error = err),
                 LogSeverity::Error,
                 cx,
             );
@@ -1875,7 +1876,7 @@ impl AppView {
         let id = snapshot.id.clone();
         if let Err(err) = self.profile_store.restore(snapshot) {
             self.log_event(
-                format!("Couldn't restore profile: {err}"),
+                t!("app.restore_failed", error = err),
                 LogSeverity::Error,
                 cx,
             );
@@ -1888,7 +1889,7 @@ impl AppView {
         cx.notify();
         self.signal_profiles_changed(cx);
         self.log_event(
-            format!("Restored profile \u{201C}{name}\u{201D}"),
+            t!("app.restored_profile", name = name),
             LogSeverity::Info,
             cx,
         );
@@ -1998,7 +1999,7 @@ impl AppView {
                 // xdg-decoration) renders no title bar at all,
                 // leaving the window unmovable.
                 titlebar: Some(TitlebarOptions {
-                    title: Some("Settings · Baudrun".into()),
+                    title: Some(t!("app.settings_window_title").into()),
                     traffic_light_position: Some(gpui::point(
                         px(TRAFFIC_LIGHT_POSITION_PX),
                         px(TRAFFIC_LIGHT_POSITION_PX),
@@ -2144,15 +2145,16 @@ impl AppView {
             let _ = this.update_in(cx, |_, window, cx| match result {
                 Ok(()) => {
                     window.push_notification(
-                        Notification::success(SharedString::from("Break sent")),
+                        Notification::success(SharedString::from(t!("app.break_sent"))),
                         cx,
                     );
                 }
                 Err(err) => {
                     log::error!("send break: {err}");
                     window.push_notification(
-                        Notification::error(SharedString::from(format!(
-                            "Couldn't send break: {err}"
+                        Notification::error(SharedString::from(t!(
+                            "app.break_failed",
+                            error = err
                         ))),
                         cx,
                     );
@@ -2171,7 +2173,7 @@ impl AppView {
         self.session_overflow_open = false;
         if self.transfer_io.is_none() {
             window.push_notification(
-                Notification::error(SharedString::from("Connect to a port before sending hex.")),
+                Notification::error(SharedString::from(t!("app.connect_before_hex"))),
                 cx,
             );
             return;
@@ -2194,7 +2196,7 @@ impl AppView {
             let app_cancel = app.clone();
             let error_for_render = error.clone();
             let live_err = error_for_render.lock().unwrap().clone();
-            dlg.title(SharedString::from("Send hex bytes"))
+            dlg.title(SharedString::from(t!("app.send_hex_title")))
                 .w(px(560.0))
                 .close_button(true)
                 .on_close(move |_, _, cx| {
@@ -2206,17 +2208,17 @@ impl AppView {
                         .flex_col()
                         .gap_3()
                         .text_size(px(13.0))
-                        .child(div().text_color(rgba(0x808080AAu32)).child(
-                            "Space-separated, compact, or 0x-prefixed — all \
-                                 equivalent: 02 FF AA 55, 02FFAA55, \
-                                 0x02 0xFF 0xAA 0x55.",
-                        ))
+                        .child(
+                            div()
+                                .text_color(rgba(0x808080AAu32))
+                                .child(t!("app.send_hex_help")),
+                        )
                         .child(Input::new(&input).appearance(true))
                         .children(live_err.map(|err| {
                             div()
                                 .text_size(px(12.0))
                                 .text_color(rgba(0xCC4444FFu32))
-                                .child(SharedString::from(format!("Invalid: {err}")))
+                                .child(SharedString::from(t!("app.invalid", error = err)))
                         }))
                         .child(
                             div()
@@ -2225,14 +2227,14 @@ impl AppView {
                                 .justify_end()
                                 .gap_2()
                                 .child(send_file_secondary_button(
-                                    "Cancel",
+                                    t!("app.cancel"),
                                     move |_, window, cx| {
                                         let _ = &app_cancel;
                                         window.close_dialog(cx);
                                     },
                                 ))
                                 .child(send_file_primary_button(
-                                    "Send",
+                                    t!("app.send"),
                                     true,
                                     move |_, window, cx| {
                                         let app = app_send.clone();
@@ -2264,12 +2266,12 @@ impl AppView {
         let raw = state.input.read(cx).value().to_string();
         match parse_hex_string(&raw) {
             Ok(bytes) if bytes.is_empty() => {
-                *state.error.lock().unwrap() = Some("empty".into());
+                *state.error.lock().unwrap() = Some(t!("app.hex_empty").into());
                 cx.notify();
             }
             Ok(bytes) => {
                 let Some(io) = self.transfer_io.as_ref() else {
-                    *state.error.lock().unwrap() = Some("not connected".into());
+                    *state.error.lock().unwrap() = Some(t!("app.not_connected").into());
                     cx.notify();
                     return;
                 };
@@ -2282,10 +2284,11 @@ impl AppView {
                 self.send_hex = None;
                 window.close_dialog(cx);
                 window.push_notification(
-                    Notification::success(SharedString::from(format!(
-                        "Sent {count} byte{}",
-                        if count == 1 { "" } else { "s" }
-                    ))),
+                    Notification::success(SharedString::from(if count == 1 {
+                        t!("app.sent_byte_one", count = count)
+                    } else {
+                        t!("app.sent_bytes_many", count = count)
+                    })),
                     cx,
                 );
             }
@@ -2307,9 +2310,7 @@ impl AppView {
         }
         if self.transfer_io.is_none() {
             window.push_notification(
-                Notification::error(SharedString::from(
-                    "Connect to a port before sending a file.",
-                )),
+                Notification::error(SharedString::from(t!("app.connect_before_file"))),
                 cx,
             );
             return;
@@ -2347,7 +2348,7 @@ impl AppView {
             let app_choose = app.clone();
             let app_send = app.clone();
 
-            dlg.title(SharedString::from("Send file"))
+            dlg.title(SharedString::from(t!("app.send_file_title")))
                 .w(px(560.0))
                 .close_button(true)
                 .on_close(move |_, _, cx| {
@@ -2359,9 +2360,9 @@ impl AppView {
                         .flex_col()
                         .gap_3()
                         .text_size(px(13.0))
-                        .child(send_file_field_label("Protocol"))
+                        .child(send_file_field_label(t!("app.protocol")))
                         .child(Select::new(&protocol))
-                        .child(send_file_field_label("File"))
+                        .child(send_file_field_label(t!("app.file")))
                         .child(
                             div()
                                 .flex()
@@ -2381,13 +2382,7 @@ impl AppView {
                                 .text_size(px(12.0))
                                 .text_color(rgba(0x808080AAu32))
                                 .whitespace_normal()
-                                .child(
-                                    "Start the receiver on the target device first \
-                                     (rx, loady, bootloader \u{201C}Receive File\u{201D} \
-                                     menu, etc.) before clicking Send. The transfer \
-                                     waits up to 60 s for the receiver's handshake \
-                                     before giving up.",
-                                ),
+                                .child(t!("app.send_file_help")),
                         )
                         .child(
                             div()
@@ -2396,7 +2391,7 @@ impl AppView {
                                 .justify_end()
                                 .gap_2()
                                 .child(send_file_secondary_button(
-                                    "Cancel",
+                                    t!("app.cancel"),
                                     move |_, window, cx| {
                                         // Dismissing the overlay triggers
                                         // `on_close` which clears state.
@@ -2405,7 +2400,7 @@ impl AppView {
                                     },
                                 ))
                                 .child(send_file_primary_button(
-                                    "Send",
+                                    t!("app.send"),
                                     send_enabled,
                                     move |_, window, cx| {
                                         let app = app_send.clone();
@@ -2441,7 +2436,10 @@ impl AppView {
             Ok(d) => d,
             Err(err) => {
                 window.push_notification(
-                    Notification::error(SharedString::from(format!("Couldn't read file: {err}"))),
+                    Notification::error(SharedString::from(t!(
+                        "app.read_file_failed",
+                        error = err
+                    ))),
                     cx,
                 );
                 return;
@@ -2451,7 +2449,7 @@ impl AppView {
         let filename: SharedString = path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "(unknown)".into())
+            .unwrap_or_else(|| t!("app.unknown_file").into_owned())
             .into();
 
         // Inbound bytes during the transfer flow through this
@@ -2549,8 +2547,9 @@ impl AppView {
                 0
             };
             let app = app.clone();
-            dlg.title(SharedString::from(format!(
-                "Sending \u{201C}{filename_for_dialog}\u{201D}"
+            dlg.title(SharedString::from(t!(
+                "app.sending_file",
+                name = filename_for_dialog
             )))
             .w(px(420.0))
             .child(
@@ -2593,7 +2592,7 @@ impl AppView {
                                 .border_color(rgba(0x80808055u32))
                                 .text_size(px(12.0))
                                 .cursor_pointer()
-                                .child("Cancel")
+                                .child(t!("app.cancel"))
                                 .on_mouse_up(
                                     MouseButton::Left,
                                     move |_evt: &MouseUpEvent, _window, cx| {
@@ -2638,7 +2637,7 @@ impl AppView {
             .transfer
             .as_ref()
             .map(|t| t.filename.clone())
-            .unwrap_or_else(|| SharedString::from("file"));
+            .unwrap_or_else(|| SharedString::from(t!("app.file_fallback")));
         self.transfer = None;
         // Belt-and-braces: the transfer thread already cleared the
         // sink, but if it died on a panic before reaching that line
@@ -2650,15 +2649,13 @@ impl AppView {
         match result {
             TransferResult::Ok => {
                 window.push_notification(
-                    Notification::success(SharedString::from(format!(
-                        "Sent \u{201C}{filename}\u{201D}"
-                    ))),
+                    Notification::success(SharedString::from(t!("app.sent_file", name = filename))),
                     cx,
                 );
             }
             TransferResult::Err(msg) => {
                 window.push_notification(
-                    Notification::error(SharedString::from(format!("Transfer failed: {msg}"))),
+                    Notification::error(SharedString::from(t!("app.transfer_failed", error = msg))),
                     cx,
                 );
             }
@@ -2675,7 +2672,7 @@ impl AppView {
             files: true,
             directories: false,
             multiple: false,
-            prompt: Some("Choose a file to send".into()),
+            prompt: Some(t!("app.choose_file_prompt").into()),
         });
         cx.spawn(async move |this, cx| {
             let Ok(Ok(Some(paths))) = receiver.await else {
@@ -2885,7 +2882,7 @@ impl AppView {
             }
         }
         cx.notify();
-        self.log_event("Session kept alive in background", LogSeverity::Info, cx);
+        self.log_event(t!("app.session_suspended"), LogSeverity::Info, cx);
     }
 
     /// Resume a suspended session. Closes any open editor (matching
@@ -2917,15 +2914,15 @@ impl AppView {
             .send(serial_io::ControlSignal::Dtr(next))
             .is_err()
         {
-            self.log_event("DTR toggle failed: session closed", LogSeverity::Error, cx);
+            self.log_event(t!("app.dtr_toggle_failed"), LogSeverity::Error, cx);
             return;
         }
         self.dtr_asserted = next;
         self.log_event(
             if next {
-                "DTR asserted"
+                t!("app.dtr_asserted")
             } else {
-                "DTR deasserted"
+                t!("app.dtr_deasserted")
             },
             LogSeverity::Info,
             cx,
@@ -2944,15 +2941,15 @@ impl AppView {
             .send(serial_io::ControlSignal::Rts(next))
             .is_err()
         {
-            self.log_event("RTS toggle failed: session closed", LogSeverity::Error, cx);
+            self.log_event(t!("app.rts_toggle_failed"), LogSeverity::Error, cx);
             return;
         }
         self.rts_asserted = next;
         self.log_event(
             if next {
-                "RTS asserted"
+                t!("app.rts_asserted")
             } else {
-                "RTS deasserted"
+                t!("app.rts_deasserted")
             },
             LogSeverity::Info,
             cx,
@@ -3061,7 +3058,7 @@ impl AppView {
             // dismiss; no OK / Cancel footer needed for a sheet
             // that's purely informational.
             dialog
-                .title("About Baudrun")
+                .title(t!("app.about_title"))
                 .close_button(true)
                 .width(px(360.0))
                 .child(about_dialog_body())
@@ -3123,13 +3120,13 @@ impl AppView {
             .update(cx, |bus, cx| bus.replace(next, cx))
         {
             self.log_event(
-                format!("Font size update failed: {err}"),
+                t!("app.font_size_update_failed", error = err),
                 LogSeverity::Error,
                 cx,
             );
             return;
         }
-        self.log_event(format!("Font size: {target}"), LogSeverity::Info, cx);
+        self.log_event(t!("app.font_size", size = target), LogSeverity::Info, cx);
     }
 
     /// Move the live serial session out of this window into a freshly
@@ -3163,13 +3160,13 @@ impl AppView {
             self.themes_store.clone(),
         ) {
             self.log_event(
-                format!("Move session failed: {err}"),
+                t!("app.move_session_failed", error = err),
                 LogSeverity::Error,
                 cx,
             );
             return;
         }
-        self.log_event("Session moved to new window", LogSeverity::Info, cx);
+        self.log_event(t!("app.session_moved"), LogSeverity::Info, cx);
     }
 
     /// Complete (or cancel) a profile-drag tear-off. Fired by the
@@ -4113,12 +4110,12 @@ fn profile_row(
     let tokens = *cx.global::<SkinTokens>();
     let id = profile.id.clone();
     let name = if profile.name.is_empty() {
-        "(unnamed)".to_string()
+        t!("app.unnamed").to_string()
     } else {
         profile.name.clone()
     };
     let port = if profile.port_name.is_empty() {
-        "no port set".to_string()
+        t!("app.no_port").to_string()
     } else {
         profile.port_name.clone()
     };
@@ -4317,7 +4314,7 @@ fn profile_icon(
     let tokens = *cx.global::<SkinTokens>();
     let id = profile.id.clone();
     let name = if profile.name.is_empty() {
-        "(unnamed)".to_string()
+        t!("app.unnamed").to_string()
     } else {
         profile.name.clone()
     };

--- a/src/app_view/mod.rs
+++ b/src/app_view/mod.rs
@@ -630,12 +630,27 @@ impl AppView {
     ///    session — toggling packs in Settings → Highlighting
     ///    re-coloures incoming bytes without a reconnect.
     fn apply_settings(&mut self, settings: &settings::Settings, cx: &mut Context<Self>) {
+        self.apply_locale(settings);
         self.apply_skin(settings, cx);
         self.apply_palette(cx);
         self.apply_highlight(cx);
         self.apply_font_size(settings, cx);
         self.apply_scrollback(settings, cx);
         self.apply_copy_on_select(settings, cx);
+    }
+
+    /// Re-install the UI locale from settings. `gpui_component::set_locale`
+    /// sets a process-global that both gpui-component's widget chrome and
+    /// (from Phase A.2 on) Baudrun's own `t!()` strings read, so this one
+    /// call re-languages everything the next time `render` runs. Because
+    /// `apply_settings` fires from the SettingsBus subscription in EVERY
+    /// window, a language change made in one window re-installs the locale
+    /// and re-renders all of them — the same cross-window path skin and
+    /// font changes already use. Idempotent + cheap (just a global string
+    /// write) so running it on every settings change is fine. See
+    /// src/i18n.rs + issue #72.
+    fn apply_locale(&self, settings: &settings::Settings) {
+        gpui_component::set_locale(crate::i18n::resolve(&settings.locale));
     }
 
     /// Mirror the global `copy_on_select` flag into the live

--- a/src/app_view/mod.rs
+++ b/src/app_view/mod.rs
@@ -1306,7 +1306,7 @@ impl AppView {
         let connect_message = if was_reconnecting {
             "Reconnected".to_string()
         } else {
-            format!("Connected to {} @ {}", &port, baud)
+            format!("Connected to {port} @ {baud}")
         };
         self.connected_profile_id = Some(profile.id);
         // A successful (re)connect ends any auto-reconnect window —

--- a/src/app_view/opts.rs
+++ b/src/app_view/opts.rs
@@ -89,19 +89,13 @@ pub(super) fn read_select(state: &Entity<SelectState<Vec<Opt>>>, cx: &Context<Ap
 // takes the `Vec<Opt>` by value into the SelectState.
 
 pub(super) fn baud_opts() -> Vec<Opt> {
-    [
-        ("9600", "9600 (default)"),
-        ("19200", "19200"),
-        ("38400", "38400"),
-        ("57600", "57600"),
-        ("115200", "115200"),
-        ("230400", "230400"),
-        ("460800", "460800"),
-        ("921600", "921600"),
-    ]
-    .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
-    .collect()
+    let mut opts = vec![Opt::new("9600", &t!("opts.baud.9600"))];
+    for rate in [
+        "19200", "38400", "57600", "115200", "230400", "460800", "921600",
+    ] {
+        opts.push(Opt::new(rate, rate));
+    }
+    opts
 }
 
 pub(super) fn data_bits_opts() -> Vec<Opt> {
@@ -113,14 +107,14 @@ pub(super) fn data_bits_opts() -> Vec<Opt> {
 
 pub(super) fn parity_opts() -> Vec<Opt> {
     [
-        ("none", "None"),
-        ("odd", "Odd"),
-        ("even", "Even"),
-        ("mark", "Mark"),
-        ("space", "Space"),
+        ("none", t!("opts.parity.none")),
+        ("odd", t!("opts.parity.odd")),
+        ("even", t!("opts.parity.even")),
+        ("mark", t!("opts.parity.mark")),
+        ("space", t!("opts.parity.space")),
     ]
     .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
+    .map(|(id, title)| Opt::new(id, &title))
     .collect()
 }
 
@@ -133,23 +127,23 @@ pub(super) fn stop_bits_opts() -> Vec<Opt> {
 
 pub(super) fn flow_control_opts() -> Vec<Opt> {
     [
-        ("none", "None"),
-        ("rtscts", "RTS/CTS"),
-        ("xonxoff", "XON/XOFF"),
+        ("none", t!("opts.flow_control.none")),
+        ("rtscts", t!("opts.flow_control.rtscts")),
+        ("xonxoff", t!("opts.flow_control.xonxoff")),
     ]
     .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
+    .map(|(id, title)| Opt::new(id, &title))
     .collect()
 }
 
 pub(super) fn line_ending_opts() -> Vec<Opt> {
     [
-        ("cr", "CR (\\r) — switches, routers"),
-        ("lf", "LF (\\n) — Linux consoles"),
-        ("crlf", "CRLF (\\r\\n) — legacy / Windows"),
+        ("cr", t!("opts.line_ending.cr")),
+        ("lf", t!("opts.line_ending.lf")),
+        ("crlf", t!("opts.line_ending.crlf")),
     ]
     .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
+    .map(|(id, title)| Opt::new(id, &title))
     .collect()
 }
 
@@ -159,22 +153,22 @@ pub(super) fn line_ending_opts() -> Vec<Opt> {
 /// "default" carries the same semantics ("leave as-is").
 pub(super) fn line_policy_opts() -> Vec<Opt> {
     [
-        ("default", "Default (leave as-is)"),
-        ("assert", "Assert (high)"),
-        ("deassert", "Deassert (low)"),
+        ("default", t!("opts.line_policy.default")),
+        ("assert", t!("opts.line_policy.assert")),
+        ("deassert", t!("opts.line_policy.deassert")),
     ]
     .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
+    .map(|(id, title)| Opt::new(id, &title))
     .collect()
 }
 
 pub(super) fn backspace_opts() -> Vec<Opt> {
     [
-        ("del", "DEL (0x7F) — VT100, xterm, modern"),
-        ("bs", "BS (0x08) — older Cisco, Foundry"),
+        ("del", t!("opts.backspace.del")),
+        ("bs", t!("opts.backspace.bs")),
     ]
     .into_iter()
-    .map(|(id, title)| Opt::new(id, title))
+    .map(|(id, title)| Opt::new(id, &title))
     .collect()
 }
 
@@ -211,7 +205,7 @@ pub(super) fn port_opts(keep_selected: &str) -> Vec<Opt> {
     if !keep_selected.is_empty() && !detected.iter().any(|p| p.name == keep_selected) {
         // Prepend so the user's saved port shows up first when
         // it isn't currently detected (cable unplugged, etc.).
-        let title = format!("{keep_selected} (not connected)");
+        let title = t!("opts.port_not_connected", port = keep_selected);
         opts.insert(0, Opt::new(keep_selected, &title));
     }
     opts

--- a/src/app_view/transfer_ui.rs
+++ b/src/app_view/transfer_ui.rs
@@ -48,11 +48,11 @@ pub(super) fn transfer_protocol_opts() -> Vec<Opt> {
 }
 
 /// Small uppercase-ish field label above an input row.
-pub(super) fn send_file_field_label(label: &'static str) -> gpui::Div {
+pub(super) fn send_file_field_label(label: impl Into<SharedString>) -> gpui::Div {
     div()
         .text_size(px(11.0))
         .text_color(rgba(0x808080CCu32))
-        .child(label)
+        .child(label.into())
 }
 
 /// Read-only path display — input-styled pill that shows the chosen
@@ -103,7 +103,10 @@ where
 /// Cancel-style button at the bottom of the dialog. Quiet styling
 /// (matches Tauri's secondary button) so it doesn't compete with
 /// the primary Send button.
-pub(super) fn send_file_secondary_button<F>(label: &'static str, on_click: F) -> gpui::Div
+pub(super) fn send_file_secondary_button<F>(
+    label: impl Into<SharedString>,
+    on_click: F,
+) -> gpui::Div
 where
     F: Fn(&MouseUpEvent, &mut Window, &mut gpui::App) + 'static,
 {
@@ -116,7 +119,7 @@ where
         .text_size(px(13.0))
         .cursor_pointer()
         .hover(|st| st.bg(rgba(0x80808033u32)))
-        .child(label)
+        .child(label.into())
         .on_mouse_up(MouseButton::Left, on_click)
 }
 
@@ -124,7 +127,7 @@ where
 /// false) still renders but ignores clicks and dims out, matching
 /// Tauri's "you must pick a file first" affordance.
 pub(super) fn send_file_primary_button<F>(
-    label: &'static str,
+    label: impl Into<SharedString>,
     enabled: bool,
     on_click: F,
 ) -> gpui::Div
@@ -148,7 +151,7 @@ where
         .bg(rgba(bg))
         .text_size(px(13.0))
         .text_color(rgba(text_color))
-        .child(label);
+        .child(label.into());
     if enabled {
         btn = btn
             .cursor_pointer()

--- a/src/data/settings.rs
+++ b/src/data/settings.rs
@@ -36,6 +36,14 @@ pub struct Settings {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub appearance: String,
 
+    /// UI language as a BCP-47-ish locale code (`"en"`, `"zh-CN"`).
+    /// Empty / missing means "follow the OS locale" — `i18n::resolve`
+    /// reads `sys-locale` in that case. Codes must match an entry in
+    /// `i18n::SUPPORTED`; an unrecognised value falls back to OS →
+    /// English. See `src/i18n.rs`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub locale: String,
+
     /// PuTTY-style auto-copy on mouse selection release.
     #[serde(default, skip_serializing_if = "is_false")]
     pub copy_on_select: bool,
@@ -178,6 +186,7 @@ impl Default for Settings {
             disable_driver_detection: false,
             skin_id: "baudrun".into(),
             appearance: "auto".into(),
+            locale: String::new(),
             copy_on_select: false,
             screen_reader_mode: false,
             scrollback_lines: 10_000,

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -179,4 +179,36 @@ mod tests {
         assert_eq!(match_os_locale("en-US"), Some("en"));
         assert_eq!(match_os_locale("en_GB.UTF-8"), Some("en"));
     }
+
+    /// Guards the whole `i18n!` wiring: if the `locales/*.yml` files
+    /// don't actually register (wrong `_version` header, wrong dir,
+    /// macro not in crate root, …), `t!()` silently echoes the key
+    /// back and the UI shows `welcome.heading` instead of a string.
+    /// The build still succeeds and every other test still passes,
+    /// so without this check the breakage only shows up on screen.
+    /// Asserts real values in both shipped locales.
+    #[test]
+    fn translations_actually_resolve() {
+        rust_i18n::set_locale("en");
+        assert_eq!(t!("app.saved"), "Saved");
+        assert_eq!(t!("welcome.heading"), "Baudrun");
+        assert_ne!(
+            t!("settings.language_title"),
+            "settings.language_title",
+            "t!() echoed the key — locale files did not register"
+        );
+
+        rust_i18n::set_locale("zh-CN");
+        assert_eq!(t!("app.saved"), "已保存");
+        assert_eq!(t!("settings.language_title"), "语言");
+
+        // Interpolation must substitute, not print the placeholder.
+        rust_i18n::set_locale("en");
+        assert_eq!(t!("app.font_size", size = 14), "Font size: 14");
+
+        // A key only in en.yml resolves to English under zh-CN
+        // (fallback), never to the raw key.
+        rust_i18n::set_locale("zh-CN");
+        assert_ne!(t!("app.saved"), "app.saved");
+    }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,182 @@
+//! UI-language resolution + locale install.
+//!
+//! Phase A.1 of the localization work (see TODO.md "Localization
+//! (i18n)"): this module resolves which locale the app should run in
+//! and installs it via `gpui_component::set_locale`, which drives the
+//! `rust-i18n` global that gpui-component's own widget chrome
+//! (dialogs, pagination, calendar, etc.) reads. gpui-component bundles
+//! `en`, `zh-CN`, `zh-HK`, and `it` translations, so this alone gives
+//! a Chinese-locale user translated widget chrome before Baudrun's own
+//! strings are extracted (that's Phase A.2, which adds `rust-i18n` +
+//! `locales/*.yml` and wraps Baudrun's ~180 strings in `t!()` — the
+//! same global locale set here will cover both layers).
+//!
+//! Requested in issue #72.
+
+/// Locale codes Baudrun ships (or intends to ship) UI translations
+/// for, each paired with its endonym (name in its own language) so
+/// the future language picker reads correctly to a user already in
+/// the "wrong" locale. English first, then by endonym.
+///
+/// `zh-CN` (Simplified Chinese) is the first non-English target —
+/// issue #72's reporter writes Simplified Chinese, and gpui-component
+/// already ships matching `zh-CN` widget strings. Traditional
+/// (`zh-TW` / `zh-HK`) is intentionally absent until someone asks:
+/// see `match_os_locale`, which routes Traditional OS locales to
+/// English rather than silently showing a Traditional user
+/// Simplified text.
+pub const SUPPORTED: &[(&str, &str)] = &[("en", "English"), ("zh-CN", "简体中文")];
+
+/// Default / fallback locale. Must be a code gpui-component itself
+/// ships, and the language every Baudrun string is authored in.
+pub const DEFAULT: &str = "en";
+
+/// Resolve the active locale and install it via
+/// `gpui_component::set_locale`. Called once at boot from `main::run`
+/// with the persisted `Settings.locale`. Returns the installed code
+/// for logging.
+pub fn init(override_code: &str) -> &'static str {
+    let resolved = resolve(override_code);
+    gpui_component::set_locale(resolved);
+    log::info!("i18n: locale set to {resolved} (settings.locale={override_code:?})");
+    resolved
+}
+
+/// Pure resolution — no side effects, unit-testable. Precedence:
+///
+/// 1. `override_code` — the persisted `Settings.locale` when the user
+///    picked one. Empty string means "unset / follow the OS".
+/// 2. The OS locale via `sys-locale`, matched against `SUPPORTED`
+///    with Simplified/Traditional Chinese awareness (see
+///    `match_os_locale`).
+/// 3. `DEFAULT` (English).
+pub fn resolve(override_code: &str) -> &'static str {
+    // 1. Explicit user choice from settings.
+    if !override_code.is_empty() {
+        if let Some(code) = supported(override_code) {
+            return code;
+        }
+        log::warn!("i18n: settings.locale {override_code:?} not in SUPPORTED — ignoring");
+    }
+
+    // 2. OS locale. `sys-locale` returns the platform's best guess:
+    // `defaultLocale` on macOS, `LANG`/`LC_ALL` on Linux,
+    // `GetUserDefaultLocaleName` on Windows.
+    if let Some(os) = sys_locale::get_locale() {
+        if let Some(code) = match_os_locale(&os) {
+            return code;
+        }
+    }
+
+    // 3. Fallback.
+    DEFAULT
+}
+
+/// Map a raw OS locale string to a `SUPPORTED` code, or `None`.
+///
+/// The important case is Chinese. PortFinder (the sibling app whose
+/// i18n this is modelled on) strips every OS locale to its bare
+/// language subtag — `zh-Hans-CN` → `zh` — and matches that. For its
+/// seven Latin-script languages that's fine, but bare `zh` never
+/// matches a region-qualified `zh-CN`, so a mainland user would fall
+/// through to English. Baudrun keeps the script/region subtags and
+/// decides Simplified vs Traditional from them.
+fn match_os_locale(os: &str) -> Option<&'static str> {
+    let lower = os.to_ascii_lowercase();
+    // BCP-47 uses `-`; some Unix locales use `_`; a trailing
+    // `.UTF-8`/`.utf8` codeset is `.`-separated. Split on all three.
+    let mut subtags = lower.split(['-', '_', '.']).filter(|s| !s.is_empty());
+    let lang = subtags.next()?;
+    let rest: Vec<&str> = subtags.collect();
+
+    if lang == "zh" {
+        // Traditional if the script (`Hant`) or a Traditional-using
+        // region (Taiwan / Hong Kong / Macau) is present. Everything
+        // else — `Hans`, `CN`, `SG`, or a bare `zh` — is Simplified,
+        // which is what mainland systems report and the majority
+        // variant to default an ambiguous `zh` to.
+        let traditional = rest
+            .iter()
+            .any(|t| matches!(*t, "hant" | "tw" | "hk" | "mo"));
+        if traditional {
+            // No Traditional catalog yet — prefer English over
+            // showing a Traditional reader Simplified text. Reorders
+            // to a real match automatically once `zh-TW`/`zh-HK`
+            // join SUPPORTED.
+            return supported("zh-tw").or_else(|| supported("zh-hk"));
+        }
+        return supported("zh-cn");
+    }
+
+    // Non-Chinese: match the OS language subtag against the language
+    // portion of each SUPPORTED code (so `en-US` → `en`).
+    SUPPORTED
+        .iter()
+        .find(|(code, _)| {
+            code.split('-')
+                .next()
+                .map(str::to_ascii_lowercase)
+                .as_deref()
+                == Some(lang)
+        })
+        .map(|(code, _)| *code)
+}
+
+/// Case-insensitive lookup of a `SUPPORTED` code, returning the
+/// canonically-cased entry (`"zh-cn"` → `"zh-CN"`).
+fn supported(code: &str) -> Option<&'static str> {
+    SUPPORTED
+        .iter()
+        .find(|(c, _)| c.eq_ignore_ascii_case(code))
+        .map(|(c, _)| *c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_override_wins_and_is_case_insensitive() {
+        assert_eq!(resolve("zh-CN"), "zh-CN");
+        assert_eq!(resolve("zh-cn"), "zh-CN");
+        assert_eq!(resolve("en"), "en");
+    }
+
+    #[test]
+    fn simplified_chinese_os_locales_resolve_to_zh_cn() {
+        // The bug PortFinder's bare-language strip would hit: every
+        // one of these must reach zh-CN, not fall through to English.
+        for os in [
+            "zh",
+            "zh-CN",
+            "zh_CN",
+            "zh-Hans",
+            "zh-Hans-CN",
+            "zh-CN.UTF-8",
+            "zh-SG",
+        ] {
+            assert_eq!(match_os_locale(os), Some("zh-CN"), "{os}");
+        }
+    }
+
+    #[test]
+    fn traditional_chinese_falls_through_until_shipped() {
+        // No Traditional catalog yet → None (caller uses English)
+        // rather than silently serving Simplified.
+        for os in ["zh-TW", "zh-Hant", "zh-Hant-TW", "zh-HK", "zh-MO"] {
+            assert_eq!(match_os_locale(os), None, "{os}");
+        }
+    }
+
+    #[test]
+    fn unknown_os_locale_is_none() {
+        assert_eq!(match_os_locale("de-DE"), None);
+        assert_eq!(match_os_locale("fr"), None);
+    }
+
+    #[test]
+    fn english_os_locales_match() {
+        assert_eq!(match_os_locale("en-US"), Some("en"));
+        assert_eq!(match_os_locale("en_GB.UTF-8"), Some("en"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,19 @@
     windows_subsystem = "windows"
 )]
 
+// `#[macro_use]` brings `t!` into scope crate-wide so call sites in
+// every module can write `t!("key")` without an import. `i18n!`
+// compiles every `locales/*.yml` into the binary at build time with
+// English as the fallback for any key a locale is missing. The active
+// locale is the process-global set by `i18n::init` /
+// `AppView::apply_locale` via `gpui_component::set_locale` — the same
+// global gpui-component's own widget strings read, so one locale
+// switch re-languages both layers. See src/i18n.rs + issue #72.
+#[macro_use]
+extern crate rust_i18n;
+
+rust_i18n::i18n!("locales", fallback = "en");
+
 mod app_view;
 mod data;
 mod highlight_runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@
 mod app_view;
 mod data;
 mod highlight_runtime;
+mod i18n;
 mod profiles_bus;
 mod serial_io;
 mod settings_bus;
@@ -326,7 +327,15 @@ fn main() {
         // live-applies to all of them. Built before the TerminalView
         // so the boot scrollback can come from the persisted value.
         let settings_bus = cx.new(|_| SettingsBus::new(settings_store.clone()));
-        let boot_scrollback = settings_bus.read(cx).current().effective_scrollback();
+        let boot_settings = settings_bus.read(cx).current();
+        let boot_scrollback = boot_settings.effective_scrollback();
+
+        // Install the UI locale before any window builds. Drives
+        // gpui-component's own `rust-i18n` global (translated widget
+        // chrome for zh-CN et al.); Phase A.2 will extend the same
+        // global to Baudrun's own strings. `""` locale = follow the
+        // OS. See src/i18n.rs + issue #72.
+        i18n::init(&boot_settings.locale);
 
         // Build the TerminalView entity. Boot palette = the
         // hardcoded Baudrun default. AppView re-applies the user's

--- a/src/settings_view/chrome.rs
+++ b/src/settings_view/chrome.rs
@@ -70,7 +70,7 @@ pub(super) fn window_header(
                             div()
                                 .text_size(px(s.font_size_h1_px))
                                 .text_color(rgba(s.fg_primary))
-                                .child("Settings"),
+                                .child(t!("settings_chrome.title")),
                         )
                         .child(
                             div()
@@ -96,9 +96,9 @@ pub(super) fn window_header(
                                 // (currently "0.0.1").
                                 .child(format!("v{}", env!("CARGO_PKG_VERSION")))
                                 .tooltip(|window, cx| {
-                                    Tooltip::new(SharedString::from(
-                                        "Baudrun version (from Cargo.toml at build time)",
-                                    ))
+                                    Tooltip::new(SharedString::from(t!(
+                                        "settings_chrome.version_tooltip"
+                                    )))
                                     .build(window, cx)
                                 }),
                         ),
@@ -111,7 +111,10 @@ pub(super) fn window_header(
                         .text_size(px(s.font_size_label_px))
                         .text_color(rgba(s.fg_tertiary))
                         .font_weight(gpui::FontWeight(s.label_weight as f32))
-                        .child(s.label_transform.apply("GLOBAL DEFAULTS")),
+                        .child(
+                            s.label_transform
+                                .apply(&t!("settings_chrome.global_defaults")),
+                        ),
                 ),
         )
         .child(
@@ -141,7 +144,10 @@ pub(super) fn window_header(
                             .cursor_pointer()
                             .hover(|st| st.text_color(rgba(s.fg_primary)))
                             .tooltip(|window, cx| {
-                                Tooltip::new(SharedString::from("Clear filter")).build(window, cx)
+                                Tooltip::new(SharedString::from(t!(
+                                    "settings_chrome.filter_clear_tooltip"
+                                )))
+                                .build(window, cx)
                             })
                             .child("\u{00D7}")
                             .on_mouse_up(
@@ -193,7 +199,7 @@ pub(super) fn rail(
             .map(|(_, m)| *m)
             .unwrap_or(true)
     };
-    let item = move |label: &'static str, tab: SettingsTab, dimmed: bool| {
+    let item = move |label: SharedString, tab: SettingsTab, dimmed: bool| {
         let is_active = tab == active;
         let bg = if is_active {
             rgba(s.bg_active)
@@ -218,7 +224,7 @@ pub(super) fn rail(
             // style only paints when some unrelated event happens to
             // dirty SettingsView. Same fix as `profile_row`. The label
             // is unique within the rail so it works as a stable key.
-            .id(label)
+            .id(label.clone())
             .w_full()
             .px_3()
             .py(px(6.0))
@@ -299,8 +305,8 @@ pub(super) fn scrollable_pane(content: impl IntoElement) -> impl IntoElement {
 /// `--radius-lg` tokens as the profile editor's `section_card`.
 pub(super) fn section_card_with_desc(
     s: SkinTokens,
-    title: &'static str,
-    description: Option<&'static str>,
+    title: SharedString,
+    description: Option<SharedString>,
     body: impl IntoElement,
 ) -> gpui::Div {
     let mut header = div().flex().flex_col().gap_1().child(
@@ -350,7 +356,7 @@ pub(super) fn section_card_with_desc(
 /// inside the widget so click-on-text toggles too.
 pub(super) fn bool_field<F>(
     id: &'static str,
-    label: &'static str,
+    label: impl Into<SharedString>,
     checked: bool,
     cx: &mut Context<SettingsView>,
     setter: F,
@@ -361,7 +367,7 @@ where
     div().child(
         Checkbox::new(id)
             .checked(checked)
-            .label(label)
+            .label(label.into())
             .on_click(cx.listener(move |this, checked: &bool, _, cx| {
                 setter(this, *checked, cx);
             })),
@@ -424,7 +430,7 @@ pub(super) fn encode_file_path(p: &std::path::Path) -> String {
 pub(super) fn resolve_config_dir_display() -> SharedString {
     match appdata::support_dir() {
         Ok(path) => SharedString::from(path.display().to_string()),
-        Err(err) => SharedString::from(format!("(unavailable: {err})")),
+        Err(err) => SharedString::from(t!("settings_chrome.config_dir_unavailable", err = err)),
     }
 }
 
@@ -445,7 +451,7 @@ pub(super) fn resolve_config_dir_display() -> SharedString {
 pub(super) fn import_button<F>(
     s: SkinTokens,
     id: impl Into<ElementId>,
-    label: &'static str,
+    label: impl Into<SharedString>,
     cx: &mut Context<SettingsView>,
     on_click: F,
 ) -> gpui::Div
@@ -466,7 +472,7 @@ where
             .text_size(px(12.0))
             .cursor_pointer()
             .hover(move |st| st.border_color(rgba(accent)))
-            .child(label)
+            .child(label.into())
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(move |this, _: &MouseUpEvent, window, cx| {
@@ -483,7 +489,7 @@ where
 pub(super) fn trash_button<F>(
     s: SkinTokens,
     id: impl Into<ElementId>,
-    tip: &'static str,
+    tip: impl Into<SharedString>,
     cx: &mut Context<SettingsView>,
     on_click: F,
 ) -> gpui::Div
@@ -491,7 +497,7 @@ where
     F: Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
 {
     let danger = s.danger;
-    let tip_text = SharedString::from(tip);
+    let tip_text = tip.into();
     div().child(
         div()
             .id(id)

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -154,6 +154,8 @@ pub struct SettingsView {
     _skin_sub: Subscription,
     appearance_select: Entity<SelectState<Vec<Opt>>>,
     _appearance_sub: Subscription,
+    locale_select: Entity<SelectState<Vec<Opt>>>,
+    _locale_sub: Subscription,
     font_size: Entity<InputState>,
     _font_size_sub: Subscription,
     scrollback: Entity<InputState>,
@@ -273,6 +275,33 @@ impl SettingsView {
                     if &this.settings.appearance != value {
                         let mut next = this.settings.clone();
                         next.appearance = value.clone();
+                        this.commit(next, cx);
+                    }
+                }
+            },
+        );
+
+        // Language picker. First option "" = follow the OS locale;
+        // the rest come from `i18n::SUPPORTED` labelled by endonym
+        // (each language in its own script) so a user in the "wrong"
+        // language can still find theirs. Committing routes through
+        // SettingsBus, so `AppView::apply_settings` re-installs the
+        // locale (`gpui_component::set_locale`) and every open window
+        // re-renders — no restart. See issue #72.
+        let mut locale_opts = vec![Opt::new("", "Auto (follow system)")];
+        locale_opts.extend(
+            crate::i18n::SUPPORTED
+                .iter()
+                .map(|(code, name)| Opt::new(code, name)),
+        );
+        let locale_select = make_select(locale_opts, &current.locale, window, cx);
+        let locale_sub = cx.subscribe(
+            &locale_select,
+            |this, _, event: &SelectEvent<Vec<Opt>>, cx| {
+                if let SelectEvent::Confirm(Some(value)) = event {
+                    if &this.settings.locale != value {
+                        let mut next = this.settings.clone();
+                        next.locale = value.clone();
                         this.commit(next, cx);
                     }
                 }
@@ -438,6 +467,8 @@ impl SettingsView {
             _skin_sub: skin_sub,
             appearance_select,
             _appearance_sub: appearance_sub,
+            locale_select,
+            _locale_sub: locale_sub,
             font_size,
             scrollback,
             _scrollback_sub: scrollback_sub,
@@ -2053,6 +2084,16 @@ impl SettingsView {
                      ignore this and pin dark.",
                 ),
                 Select::new(&self.appearance_select),
+            ))
+            .child(self.filtered_card(
+                s,
+                "Language",
+                Some(
+                    "UI language. \"Auto\" follows the operating system. \
+                     Takes effect immediately — no restart. Terminal \
+                     output is never translated.",
+                ),
+                Select::new(&self.locale_select),
             ))
             .child(installed_card)
             .child(self.filtered_card(

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -157,6 +157,13 @@ pub struct SettingsView {
     _appearance_sub: Subscription,
     locale_select: Entity<SelectState<Vec<Opt>>>,
     _locale_sub: Subscription,
+    /// Locale the `Select` option labels were last built in. A
+    /// `Select`'s option titles are baked into its `SelectState` at
+    /// construction (from `t!()`), so a plain re-render after a live
+    /// language switch keeps the old-language labels. `render`
+    /// compares this against the active locale and re-feeds
+    /// translated options via `set_items` when they differ.
+    built_locale: String,
     font_size: Entity<InputState>,
     _font_size_sub: Subscription,
     scrollback: Entity<InputState>,
@@ -470,6 +477,10 @@ impl SettingsView {
             _appearance_sub: appearance_sub,
             locale_select,
             _locale_sub: locale_sub,
+            // Seed with the locale the selects above were just built
+            // in, so render doesn't fire a spurious relabel on the
+            // first frame.
+            built_locale: gpui_component::locale().to_string(),
             font_size,
             scrollback,
             _scrollback_sub: scrollback_sub,
@@ -502,6 +513,44 @@ impl SettingsView {
     /// full, perm denied) the cache stays put and the error logs.
     /// Failure is silent in the UI today — a future slice can hang
     /// a toast off this same path.
+    /// Re-feed translated option labels to the locale-dependent
+    /// selects after a live language switch. Only the Appearance and
+    /// Language pickers need it — their option titles come from
+    /// `t!()`. The skin / theme pickers list data-driven names
+    /// (skin.name / theme.name) which are never translated, so
+    /// they're left alone. Selection is preserved across the swap.
+    /// Called from `render` (which has the `Window` `set_items`
+    /// wants) when the active locale has changed since
+    /// `built_locale`.
+    fn relabel_locale_selects(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let appearance_opts = vec![
+            Opt::new("auto", &t!("settings.appearance_auto")),
+            Opt::new("light", &t!("settings.appearance_light")),
+            Opt::new("dark", &t!("settings.appearance_dark")),
+        ];
+        let active_appearance = if self.settings.appearance.is_empty() {
+            "auto".to_string()
+        } else {
+            self.settings.appearance.clone()
+        };
+        self.appearance_select.update(cx, |state, cx| {
+            state.set_items(appearance_opts, window, cx);
+            state.set_selected_value(&active_appearance, window, cx);
+        });
+
+        let mut locale_opts = vec![Opt::new("", &t!("settings.language_auto"))];
+        locale_opts.extend(
+            crate::i18n::SUPPORTED
+                .iter()
+                .map(|(code, name)| Opt::new(code, name)),
+        );
+        let active_locale = self.settings.locale.clone();
+        self.locale_select.update(cx, |state, cx| {
+            state.set_items(locale_opts, window, cx);
+            state.set_selected_value(&active_locale, window, cx);
+        });
+    }
+
     fn commit(&mut self, next: Settings, cx: &mut Context<Self>) {
         let result = self
             .settings_bus
@@ -1570,6 +1619,16 @@ fn build_theme_opts(store: &themes::Store) -> Vec<Opt> {
 impl Render for SettingsView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let s = *cx.global::<SkinTokens>();
+        // Live language switch: if the active locale changed since the
+        // selects were labelled, re-feed translated options before
+        // building the tree. Guarded so it fires once per change, not
+        // every frame. Keyed on the actual global locale (what t!()
+        // reads) so it's correct no matter which window flipped it.
+        let active_locale = gpui_component::locale().to_string();
+        if self.built_locale != active_locale {
+            self.built_locale = active_locale;
+            self.relabel_locale_selects(window, cx);
+        }
         let dialog_layer = Root::render_dialog_layer(window, cx);
         let notification_layer = Root::render_notification_layer(window, cx);
 

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -72,16 +72,17 @@ impl SettingsTab {
         SettingsTab::Advanced,
     ];
 
-    fn label(self) -> &'static str {
-        match self {
-            SettingsTab::Appearance => "Appearance",
-            SettingsTab::Themes => "Themes",
-            SettingsTab::Shortcuts => "Shortcuts",
-            SettingsTab::Highlighting => "Highlighting",
-            SettingsTab::Accessibility => "Accessibility",
-            SettingsTab::Updates => "Updates",
-            SettingsTab::Advanced => "Advanced",
-        }
+    fn label(self) -> SharedString {
+        let label = match self {
+            SettingsTab::Appearance => t!("settings.tab.appearance"),
+            SettingsTab::Themes => t!("settings.tab.themes"),
+            SettingsTab::Shortcuts => t!("settings.tab.shortcuts"),
+            SettingsTab::Highlighting => t!("settings.tab.highlighting"),
+            SettingsTab::Accessibility => t!("settings.tab.accessibility"),
+            SettingsTab::Updates => t!("settings.tab.updates"),
+            SettingsTab::Advanced => t!("settings.tab.advanced"),
+        };
+        label.into()
     }
 }
 
@@ -258,9 +259,9 @@ impl SettingsView {
         );
 
         let appearance_opts = vec![
-            Opt::new("auto", "Auto (follow system)"),
-            Opt::new("light", "Light"),
-            Opt::new("dark", "Dark"),
+            Opt::new("auto", &t!("settings.appearance_auto")),
+            Opt::new("light", &t!("settings.appearance_light")),
+            Opt::new("dark", &t!("settings.appearance_dark")),
         ];
         let active_appearance = if current.appearance.is_empty() {
             "auto"
@@ -288,7 +289,7 @@ impl SettingsView {
         // SettingsBus, so `AppView::apply_settings` re-installs the
         // locale (`gpui_component::set_locale`) and every open window
         // re-renders — no restart. See issue #72.
-        let mut locale_opts = vec![Opt::new("", "Auto (follow system)")];
+        let mut locale_opts = vec![Opt::new("", &t!("settings.language_auto"))];
         locale_opts.extend(
             crate::i18n::SUPPORTED
                 .iter()
@@ -420,7 +421,7 @@ impl SettingsView {
 
         let log_dir = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("Default")
+                .placeholder(t!("settings.log_dir_placeholder"))
                 .default_value(current.log_dir.as_str())
         });
 
@@ -443,7 +444,7 @@ impl SettingsView {
         // `Change` (every keystroke) so the dim animates live; no
         // need to wait for Blur the way the saved-setting inputs do.
         let filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter settings\u{2026}"));
+            cx.new(|cx| InputState::new(window, cx).placeholder(t!("settings.filter_placeholder")));
         let filter_sub = cx.subscribe(&filter_input, |this, input, event: &InputEvent, cx| {
             if matches!(event, InputEvent::Change) {
                 let value = input.read(cx).value().to_string();
@@ -519,7 +520,7 @@ impl SettingsView {
                 // up `window` (the `&mut Context<Self>` we're handed
                 // here doesn't carry one).
                 log::error!("save settings: {err}");
-                let msg = format!("Couldn't save settings: {err}");
+                let msg = t!("settings.toast.save_failed", err = err);
                 cx.spawn(async move |weak, cx_async| {
                     let _ = weak.update_in(cx_async, |_, window, view_cx| {
                         window.push_notification(
@@ -579,11 +580,13 @@ impl SettingsView {
     fn filtered_card(
         &self,
         s: SkinTokens,
-        title: &'static str,
-        description: Option<&'static str>,
+        title: impl Into<SharedString>,
+        description: Option<impl Into<SharedString>>,
         body: impl IntoElement,
     ) -> gpui::Div {
-        section_card_with_desc(s, title, description, body).opacity(self.filter_opacity(title))
+        let title: SharedString = title.into();
+        let opacity = self.filter_opacity(&title);
+        section_card_with_desc(s, title, description.map(Into::into), body).opacity(opacity)
     }
 
     fn section_matches_filter(&self, title: &str) -> bool {
@@ -654,8 +657,9 @@ impl SettingsView {
                 cx.spawn(async move |this, cx| {
                     let _ = this.update_in(cx, |_, window, view_cx| {
                         window.push_notification(
-                            Notification::error(SharedString::from(format!(
-                                "Couldn't open config directory: {err}"
+                            Notification::error(SharedString::from(t!(
+                                "settings.toast.config_open_failed",
+                                err = err
                             ))),
                             view_cx,
                         );
@@ -677,7 +681,7 @@ impl SettingsView {
             files: false,
             directories: true,
             multiple: false,
-            prompt: Some("Choose Baudrun config directory".into()),
+            prompt: Some(t!("settings.prompt.choose_config_dir").into()),
         });
         cx.spawn(async move |this, cx| {
             let Ok(Ok(Some(paths))) = receiver.await else {
@@ -690,8 +694,9 @@ impl SettingsView {
                 if let Err(err) = appdata::write_override(Some(&path)) {
                     log::error!("write config dir override: {err}");
                     window.push_notification(
-                        Notification::error(SharedString::from(format!(
-                            "Couldn't set config directory: {err}"
+                        Notification::error(SharedString::from(t!(
+                            "settings.toast.config_set_failed",
+                            err = err
                         ))),
                         view_cx,
                     );
@@ -700,9 +705,7 @@ impl SettingsView {
                 this.config_dir_display = resolve_config_dir_display();
                 view_cx.notify();
                 window.push_notification(
-                    Notification::success(SharedString::from(
-                        "Config directory set. Restart Baudrun to use it.",
-                    )),
+                    Notification::success(SharedString::from(t!("settings.toast.config_set"))),
                     view_cx,
                 );
             });
@@ -716,8 +719,9 @@ impl SettingsView {
         if let Err(err) = appdata::write_override(None) {
             log::error!("clear config dir override: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!(
-                    "Couldn't reset config directory: {err}"
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.config_reset_failed",
+                    err = err
                 ))),
                 cx,
             );
@@ -726,9 +730,7 @@ impl SettingsView {
         self.config_dir_display = resolve_config_dir_display();
         cx.notify();
         window.push_notification(
-            Notification::success(SharedString::from(
-                "Config directory reset. Restart Baudrun to use the default.",
-            )),
+            Notification::success(SharedString::from(t!("settings.toast.config_reset"))),
             cx,
         );
     }
@@ -741,7 +743,7 @@ impl SettingsView {
             files: false,
             directories: true,
             multiple: false,
-            prompt: Some("Choose session log directory".into()),
+            prompt: Some(t!("settings.prompt.choose_log_dir").into()),
         });
         cx.spawn(async move |this, cx| {
             let Ok(Ok(Some(paths))) = receiver.await else {
@@ -760,7 +762,9 @@ impl SettingsView {
                     next.log_dir = path_str;
                     this.commit(next, view_cx);
                     window.push_notification(
-                        Notification::success(SharedString::from("Log directory updated")),
+                        Notification::success(SharedString::from(t!(
+                            "settings.toast.log_dir_updated"
+                        ))),
                         view_cx,
                     );
                 }
@@ -781,7 +785,7 @@ impl SettingsView {
             next.log_dir = String::new();
             self.commit(next, cx);
             window.push_notification(
-                Notification::success(SharedString::from("Log directory reset to default")),
+                Notification::success(SharedString::from(t!("settings.toast.log_dir_reset"))),
                 cx,
             );
         }
@@ -976,7 +980,7 @@ impl SettingsView {
             files: true,
             directories: false,
             multiple: false,
-            prompt: Some("Import skin JSON".into()),
+            prompt: Some(t!("settings.prompt.import_skin").into()),
         });
         let store = self.skins_store.clone();
         cx.spawn(async move |this, cx| {
@@ -993,8 +997,9 @@ impl SettingsView {
                     let _ = this.update_in(cx, |this, window, view_cx| {
                         this.rebuild_skin_select(window, view_cx);
                         window.push_notification(
-                            Notification::success(SharedString::from(format!(
-                                "Imported skin \u{201C}{name}\u{201D}"
+                            Notification::success(SharedString::from(t!(
+                                "settings.toast.skin_imported",
+                                name = name
                             ))),
                             view_cx,
                         );
@@ -1002,7 +1007,7 @@ impl SettingsView {
                 }
                 Err(err) => {
                     log::error!("import skin: {err}");
-                    let msg = format!("Couldn't import skin: {err}");
+                    let msg = t!("settings.toast.skin_import_failed", err = err);
                     let _ = this.update_in(cx, |_, window, view_cx| {
                         window.push_notification(
                             Notification::error(SharedString::from(msg)),
@@ -1020,7 +1025,7 @@ impl SettingsView {
             files: true,
             directories: false,
             multiple: false,
-            prompt: Some("Import theme (.itermcolors or JSON)".into()),
+            prompt: Some(t!("settings.prompt.import_theme").into()),
         });
         let store = self.themes_store.clone();
         cx.spawn(async move |this, cx| {
@@ -1037,8 +1042,9 @@ impl SettingsView {
                     let _ = this.update_in(cx, |this, window, view_cx| {
                         this.rebuild_theme_select(window, view_cx);
                         window.push_notification(
-                            Notification::success(SharedString::from(format!(
-                                "Imported theme \u{201C}{name}\u{201D}"
+                            Notification::success(SharedString::from(t!(
+                                "settings.toast.theme_imported",
+                                name = name
                             ))),
                             view_cx,
                         );
@@ -1046,7 +1052,7 @@ impl SettingsView {
                 }
                 Err(err) => {
                     log::error!("import theme: {err}");
-                    let msg = format!("Couldn't import theme: {err}");
+                    let msg = t!("settings.toast.theme_import_failed", err = err);
                     let _ = this.update_in(cx, |_, window, view_cx| {
                         window.push_notification(
                             Notification::error(SharedString::from(msg)),
@@ -1075,7 +1081,10 @@ impl SettingsView {
         if let Err(err) = self.skins_store.delete(&id) {
             log::error!("delete skin {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't delete skin: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.skin_delete_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1098,8 +1107,9 @@ impl SettingsView {
             None
         };
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Removed skin \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.skin_removed",
+                name = name
             )))
             .action(move |_, _, ctx| {
                 let app = app.clone();
@@ -1107,7 +1117,7 @@ impl SettingsView {
                 let prev_active_id = prev_active_id.clone();
                 let notif = ctx.entity();
                 Button::new("undo-skin-delete")
-                    .label("Undo")
+                    .label(t!("settings.undo"))
                     .on_click(move |_, window, cx| {
                         let app = app.clone();
                         let snapshot = snapshot.clone();
@@ -1145,7 +1155,10 @@ impl SettingsView {
         if let Err(err) = self.skins_store.restore(skin) {
             log::error!("restore skin {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't restore skin: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.skin_restore_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1157,8 +1170,9 @@ impl SettingsView {
         }
         self.rebuild_skin_select(window, cx);
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Restored skin \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.skin_restored",
+                name = name
             ))),
             cx,
         );
@@ -1180,7 +1194,10 @@ impl SettingsView {
         if let Err(err) = self.themes_store.delete(&id) {
             log::error!("delete theme {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't delete theme: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.theme_delete_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1199,8 +1216,9 @@ impl SettingsView {
             None
         };
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Removed theme \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.theme_removed",
+                name = name
             )))
             .action(move |_, _, ctx| {
                 let app = app.clone();
@@ -1208,7 +1226,7 @@ impl SettingsView {
                 let prev_active_id = prev_active_id.clone();
                 let notif = ctx.entity();
                 Button::new("undo-theme-delete")
-                    .label("Undo")
+                    .label(t!("settings.undo"))
                     .on_click(move |_, window, cx| {
                         let app = app.clone();
                         let snapshot = snapshot.clone();
@@ -1238,7 +1256,10 @@ impl SettingsView {
         if let Err(err) = self.themes_store.restore(theme) {
             log::error!("restore theme {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't restore theme: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.theme_restore_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1250,8 +1271,9 @@ impl SettingsView {
         }
         self.rebuild_theme_select(window, cx);
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Restored theme \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.theme_restored",
+                name = name
             ))),
             cx,
         );
@@ -1271,9 +1293,9 @@ impl SettingsView {
         };
         let title = SharedString::from(theme.name.clone());
         let subtitle = SharedString::from(if theme.source == "user" {
-            "Imported theme \u{00B7} sample output \u{00B7} last line shows text selection"
+            t!("settings.theme_preview.subtitle_imported")
         } else {
-            "Built-in theme \u{00B7} sample output \u{00B7} last line shows text selection"
+            t!("settings.theme_preview.subtitle_builtin")
         });
         window.open_dialog(cx, move |dlg, _, _| {
             // `close_button(true)` adds the `×` glyph in the title
@@ -1321,7 +1343,10 @@ impl SettingsView {
         if let Err(err) = self.highlight_store.delete_user_pack(&id) {
             log::error!("delete highlight pack {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't delete pack: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.pack_delete_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1338,15 +1363,16 @@ impl SettingsView {
         }
         let app = cx.entity();
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Removed pack \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.pack_removed",
+                name = name
             )))
             .action(move |_, _, ctx| {
                 let app = app.clone();
                 let snapshot = snapshot.clone();
                 let notif = ctx.entity();
                 Button::new("undo-pack-delete")
-                    .label("Undo")
+                    .label(t!("settings.undo"))
                     .on_click(move |_, window, cx| {
                         let app = app.clone();
                         let snapshot = snapshot.clone();
@@ -1375,7 +1401,10 @@ impl SettingsView {
         if let Err(err) = self.highlight_store.restore_user_pack(&pack) {
             log::error!("restore highlight pack {id}: {err}");
             window.push_notification(
-                Notification::error(SharedString::from(format!("Couldn't restore pack: {err}"))),
+                Notification::error(SharedString::from(t!(
+                    "settings.toast.pack_restore_failed",
+                    err = err
+                ))),
                 cx,
             );
             return;
@@ -1392,8 +1421,9 @@ impl SettingsView {
             cx.notify();
         }
         window.push_notification(
-            Notification::success(SharedString::from(format!(
-                "Restored pack \u{201C}{name}\u{201D}"
+            Notification::success(SharedString::from(t!(
+                "settings.toast.pack_restored",
+                name = name
             ))),
             cx,
         );
@@ -1404,7 +1434,7 @@ impl SettingsView {
             files: true,
             directories: false,
             multiple: false,
-            prompt: Some("Import highlight pack JSON".into()),
+            prompt: Some(t!("settings.prompt.import_pack").into()),
         });
         let store = self.highlight_store.clone();
         cx.spawn(async move |this, cx| {
@@ -1424,8 +1454,9 @@ impl SettingsView {
                     let _ = this.update_in(cx, |_, window, view_cx| {
                         view_cx.notify();
                         window.push_notification(
-                            Notification::success(SharedString::from(format!(
-                                "Imported pack \u{201C}{name}\u{201D}"
+                            Notification::success(SharedString::from(t!(
+                                "settings.toast.pack_imported",
+                                name = name
                             ))),
                             view_cx,
                         );
@@ -1433,7 +1464,7 @@ impl SettingsView {
                 }
                 Err(err) => {
                     log::error!("import highlight: {err}");
-                    let msg = format!("Couldn't import pack: {err}");
+                    let msg = t!("settings.toast.pack_import_failed", err = err);
                     let _ = this.update_in(cx, |_, window, view_cx| {
                         window.push_notification(
                             Notification::error(SharedString::from(msg)),
@@ -1661,7 +1692,7 @@ impl SettingsView {
                     .text_size(px(12.0))
                     .track_focus(&self.capture_focus)
                     .on_key_down(cx.listener(Self::handle_capture_key))
-                    .child("Press a key… (Esc to cancel)")
+                    .child(t!("settings.capture_prompt"))
                     .into_any_element()
             } else {
                 let display: gpui::AnyElement = match parse_spec(&effective) {
@@ -1744,15 +1775,8 @@ impl SettingsView {
 
         div().flex().flex_col().gap_3().child(self.filtered_card(
             s,
-            "Keyboard Shortcuts",
-            Some(
-                "Click a binding to record a new key combo; Escape \
-                     cancels. Use \u{21BA} to reset that row to the \
-                     platform default. macOS uses Cmd-based combos \
-                     (Cmd is never a terminal control character so plain \
-                     \u{2318}K is safe); Linux/Windows use Ctrl+Shift so \
-                     plain Ctrl+letter still passes through to the device.",
-            ),
+            t!("settings.keyboard_shortcuts_title"),
+            Some(t!("settings.keyboard_shortcuts_desc")),
             div().flex().flex_col().gap_2().children(rows),
         ))
     }
@@ -1761,8 +1785,8 @@ impl SettingsView {
         // -- Card 1: Default Theme picker --
         let default_card = self.filtered_card(
             s,
-            "Default Theme",
-            Some("Used by any profile that doesn't set its own theme."),
+            t!("settings.default_theme_title"),
+            Some(t!("settings.default_theme_desc")),
             div()
                 .flex()
                 .flex_col()
@@ -1771,7 +1795,7 @@ impl SettingsView {
                     div()
                         .text_size(px(11.0))
                         .text_color(rgba(s.fg_secondary))
-                        .child("Theme"),
+                        .child(t!("settings.theme_label")),
                 )
                 .child(Select::new(&self.theme_select)),
         );
@@ -1810,12 +1834,12 @@ impl SettingsView {
                             .flex_1()
                             .text_size(px(15.0))
                             .text_color(rgba(s.fg_primary))
-                            .child("Installed Themes"),
+                            .child(t!("settings.installed_themes_title")),
                     )
                     .child(import_button(
                         s,
                         "import-theme",
-                        "Import .itermcolors\u{2026}",
+                        t!("settings.import_itermcolors"),
                         cx,
                         |this, window, cx| this.start_theme_import(window, cx),
                     )),
@@ -1840,7 +1864,11 @@ impl SettingsView {
         let theme_id = theme.id.clone();
         let theme_id_for_delete = theme.id.clone();
         let is_custom = theme.source == "user";
-        let tag = if is_custom { "Custom" } else { "Built-in" };
+        let tag = if is_custom {
+            t!("settings.tag_custom")
+        } else {
+            t!("settings.tag_builtin")
+        };
 
         let mut right = div().flex().flex_row().items_center().gap_2();
         if is_custom {
@@ -1848,7 +1876,7 @@ impl SettingsView {
             right = right.child(trash_button(
                 s,
                 trash_id,
-                "Delete imported theme",
+                t!("settings.tip.delete_theme"),
                 cx,
                 move |this, window, cx| {
                     this.delete_named_theme(theme_id_for_delete.clone(), window, cx);
@@ -1862,7 +1890,7 @@ impl SettingsView {
             // The shape of import_button (pill, accent hover) is also
             // what we want for Preview — reuse rather than duplicate
             // a near-identical helper.
-            "Preview",
+            t!("settings.preview"),
             cx,
             move |this, window, cx| this.open_theme_preview(theme_id.clone(), window, cx),
         ));
@@ -1952,7 +1980,7 @@ impl SettingsView {
                     top = top.child(trash_button(
                         s,
                         trash_id,
-                        "Delete imported pack",
+                        t!("settings.tip.delete_pack"),
                         cx,
                         move |this, window, cx| {
                             this.delete_highlight_pack(id_for_delete.clone(), window, cx);
@@ -1978,21 +2006,15 @@ impl SettingsView {
             .child(import_button(
                 s,
                 "import-highlight",
-                "Import pack\u{2026}",
+                t!("settings.import_pack"),
                 cx,
                 |this, window, cx| this.start_highlight_import(window, cx),
             ))
             .child(div().flex().flex_col().gap_3().children(rows));
         div().flex().flex_col().gap_3().child(self.filtered_card(
             s,
-            "Highlight Packs",
-            Some(
-                "Choose which built-in or imported rule packs colorize \
-                     terminal output. Stack as many as you want — matches \
-                     from each pack are merged in order. With every box \
-                     unchecked highlighting is off, even if a profile has \
-                     it enabled.",
-            ),
+            t!("settings.highlight_packs_title"),
+            Some(t!("settings.highlight_packs_desc")),
             body,
         ))
     }
@@ -2003,12 +2025,8 @@ impl SettingsView {
         // match the Tauri layout.
         let app_skin_card = self.filtered_card(
             s,
-            "App Skin",
-            Some(
-                "How the app chrome (sidebar, panes, buttons) looks. \
-                 Doesn't affect the terminal palette — that's the \
-                 Themes tab.",
-            ),
+            t!("settings.app_skin_title"),
+            Some(t!("settings.app_skin_desc")),
             Select::new(&self.skin_select),
         );
 
@@ -2024,10 +2042,7 @@ impl SettingsView {
             div()
                 .text_size(px(12.0))
                 .text_color(rgba(s.fg_secondary))
-                .child(
-                    "No custom skins installed. Use Import to add a skin \
-                 JSON file.",
-                )
+                .child(t!("settings.no_custom_skins"))
         } else {
             div()
                 .flex()
@@ -2057,12 +2072,12 @@ impl SettingsView {
                             .flex_1()
                             .text_size(px(15.0))
                             .text_color(rgba(s.fg_primary))
-                            .child("Installed Skins"),
+                            .child(t!("settings.installed_skins_title")),
                     )
                     .child(import_button(
                         s,
                         "import-skin",
-                        "Import skin\u{2026}",
+                        t!("settings.import_skin"),
                         cx,
                         |this, window, cx| this.start_skin_import(window, cx),
                     )),
@@ -2077,44 +2092,27 @@ impl SettingsView {
             .child(app_skin_card)
             .child(self.filtered_card(
                 s,
-                "Appearance",
-                Some(
-                    "Light or dark variant of the active skin. \"Auto\" \
-                     follows the system setting. Skins flagged dark-only \
-                     ignore this and pin dark.",
-                ),
+                t!("settings.appearance_title"),
+                Some(t!("settings.appearance_desc")),
                 Select::new(&self.appearance_select),
             ))
             .child(self.filtered_card(
                 s,
-                "Language",
-                Some(
-                    "UI language. \"Auto\" follows the operating system. \
-                     Takes effect immediately — no restart. Terminal \
-                     output is never translated.",
-                ),
+                t!("settings.language_title"),
+                Some(t!("settings.language_desc")),
                 Select::new(&self.locale_select),
             ))
             .child(installed_card)
             .child(self.filtered_card(
                 s,
-                "Terminal Font Size",
-                Some(
-                    "Pixel size of the terminal pane's monospace font. \
-                     Leave blank to use the default (13). Changes the \
-                     terminal grid only — chrome text size is fixed.",
-                ),
+                t!("settings.font_size_title"),
+                Some(t!("settings.font_size_desc")),
                 Input::new(&self.font_size).small().appearance(true),
             ))
             .child(self.filtered_card(
                 s,
-                "Scrollback",
-                Some(
-                    "Lines of terminal output retained for mouse-wheel \
-                     scrollback. Higher values use more memory but let \
-                     you scroll further back through chatty sessions. \
-                     Leave blank to use the default (10000).",
-                ),
+                t!("settings.scrollback_title"),
+                Some(t!("settings.scrollback_desc")),
                 Input::new(&self.scrollback).small().appearance(true),
             ))
     }
@@ -2128,9 +2126,9 @@ impl SettingsView {
         let skin_id = skin.id.clone();
         let trash_id = ElementId::Name(SharedString::from(format!("trash-skin-{}", skin.id)));
         let tag = if !skin.supports_light {
-            "Custom \u{00B7} dark-only".to_string()
+            t!("settings.tag_custom_dark_only")
         } else {
-            "Custom".to_string()
+            t!("settings.tag_custom")
         };
         div()
             .w_full()
@@ -2165,7 +2163,7 @@ impl SettingsView {
             .child(trash_button(
                 s,
                 trash_id,
-                "Remove imported skin",
+                t!("settings.tip.remove_skin"),
                 cx,
                 move |this, window, cx| {
                     this.delete_named_skin(skin_id.clone(), window, cx);
@@ -2184,23 +2182,16 @@ impl SettingsView {
     fn accessibility_pane(&self, s: SkinTokens, cx: &mut Context<Self>) -> impl IntoElement {
         let reduce_motion = cx.global::<crate::ReduceMotion>().0;
         let status_label: SharedString = if reduce_motion {
-            "On — Baudrun is skipping the reconnect-dot pulse and \
-             holding the terminal cursor steady."
-                .into()
+            t!("settings.reduce_motion.status_on").into()
         } else {
-            "Off — Baudrun's optional animations (reconnect-dot pulse, \
-             terminal cursor blink) are on."
-                .into()
+            t!("settings.reduce_motion.status_off").into()
         };
-        let os_path: &'static str = if cfg!(target_os = "macos") {
-            "Change at System Settings → Accessibility → Display → \
-             \u{201C}Reduce motion\u{201D}."
+        let os_path = if cfg!(target_os = "macos") {
+            t!("settings.reduce_motion.path_macos")
         } else if cfg!(target_os = "windows") {
-            "Change at Settings → Accessibility → Visual effects → \
-             \u{201C}Animation effects\u{201D}."
+            t!("settings.reduce_motion.path_windows")
         } else {
-            "Change via your desktop environment's accessibility / \
-             animation settings."
+            t!("settings.reduce_motion.path_other")
         };
         let dot_color = if reduce_motion {
             s.success
@@ -2250,18 +2241,16 @@ impl SettingsView {
                     .text_color(rgba(s.fg_secondary))
                     .child(os_path),
             )
-            .child(div().text_xs().text_color(rgba(s.fg_tertiary)).child(
-                "Detected once at app launch. Relaunch Baudrun \
-                         after flipping the system setting if a value here \
-                         looks stale.",
-            ));
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(rgba(s.fg_tertiary))
+                    .child(t!("settings.reduce_motion.stale_note")),
+            );
         div().flex().flex_col().gap_3().child(self.filtered_card(
             s,
-            "Reduce Motion",
-            Some(
-                "Honours the OS preference for reduced motion. Read from \
-                 the system at launch; no per-app override.",
-            ),
+            t!("settings.reduce_motion_title"),
+            Some(t!("settings.reduce_motion_desc")),
             body,
         ))
     }
@@ -2296,25 +2285,28 @@ impl SettingsView {
         //      View Release / Dismiss buttons (or "Dismissed"
         //      label when the user has already clicked Dismiss).
         let (dot_color, status_label): (u32, SharedString) = if cur.disable_update_check {
-            (s.fg_tertiary, "Update checks are disabled.".into())
+            (s.fg_tertiary, t!("settings.updates.checks_disabled").into())
         } else if let Some(a) = available.as_ref() {
             if dismissed_match {
                 (
                     s.fg_tertiary,
-                    format!(
-                        "v{} is available — you've dismissed this version.",
-                        a.version
-                    )
-                    .into(),
+                    t!("settings.updates.available_dismissed", version = a.version).into(),
                 )
             } else {
-                (s.warn, format!("v{} is available.", a.version).into())
+                (
+                    s.warn,
+                    t!("settings.updates.available", version = a.version).into(),
+                )
             }
         } else {
-            (s.success, "Baudrun is up to date.".into())
+            (s.success, t!("settings.updates.up_to_date").into())
         };
 
-        let current_line: SharedString = format!("Currently running v{current_version}.").into();
+        let current_line: SharedString = t!(
+            "settings.updates.current_version",
+            version = current_version
+        )
+        .into();
 
         let action_row = available.clone().and_then(|a| {
             if dismissed_match || cur.disable_update_check {
@@ -2329,7 +2321,7 @@ impl SettingsView {
                         .child(import_button(
                             s,
                             "updates-view-release",
-                            "View release",
+                            t!("settings.updates.view_release"),
                             cx,
                             {
                                 let url = a.html_url.clone();
@@ -2339,7 +2331,7 @@ impl SettingsView {
                         .child(import_button(
                             s,
                             "updates-dismiss",
-                            "Dismiss this version",
+                            t!("settings.updates.dismiss"),
                             cx,
                             {
                                 let version = a.version.clone();
@@ -2404,14 +2396,14 @@ impl SettingsView {
             .gap_2()
             .child(bool_field(
                 "settings-check-updates",
-                "Check for updates on launch",
+                t!("settings.updates.check_on_launch"),
                 !cur.disable_update_check,
                 cx,
                 SettingsView::set_check_updates,
             ))
             .child(bool_field(
                 "settings-prerelease-updates",
-                "Include pre-releases (alpha / beta / rc)",
+                t!("settings.updates.include_prerelease"),
                 cur.include_prerelease_updates,
                 cx,
                 SettingsView::set_include_prerelease,
@@ -2423,23 +2415,14 @@ impl SettingsView {
             .gap_3()
             .child(self.filtered_card(
                 s,
-                "Updates",
-                Some(
-                    "Baudrun queries GitHub Releases once at app launch \
-                     for a newer version. No automatic download — when \
-                     an update is available the sidebar's gear icon \
-                     gets an amber dot and this pane shows the new \
-                     version with a button to open the Releases page.",
-                ),
+                t!("settings.updates_title"),
+                Some(t!("settings.updates_desc")),
                 status_body,
             ))
             .child(self.filtered_card(
                 s,
-                "Update Preferences",
-                Some(
-                    "Disable the check entirely, or opt into seeing \
-                     pre-release tags (`-alpha.*` / `-beta.*` / `-rc.*`).",
-                ),
+                t!("settings.update_prefs_title"),
+                Some(t!("settings.update_prefs_desc")),
                 prefs_body,
             ))
     }
@@ -2453,11 +2436,8 @@ impl SettingsView {
             .child(
                 self.filtered_card(
                     s,
-                    "Session Log Directory",
-                    Some(
-                        "Where profiles with \"Record session to file\" enabled \
-                     write their logs. Leave blank to use the default.",
-                    ),
+                    t!("settings.log_dir_title"),
+                    Some(t!("settings.log_dir_desc")),
                     div()
                         .flex()
                         .flex_row()
@@ -2471,14 +2451,14 @@ impl SettingsView {
                         .child(import_button(
                             s,
                             "log-dir-choose",
-                            "Choose\u{2026}",
+                            t!("settings.choose"),
                             cx,
                             |this, window, cx| this.choose_log_dir(window, cx),
                         ))
                         .child(import_button(
                             s,
                             "log-dir-reset",
-                            "Reset",
+                            t!("settings.reset"),
                             cx,
                             |this, window, cx| this.reset_log_dir(window, cx),
                         )),
@@ -2486,15 +2466,11 @@ impl SettingsView {
             )
             .child(self.filtered_card(
                 s,
-                "USB Driver Detection",
-                Some(
-                    "Show a banner in the profile form when a USB-serial \
-                     adapter is plugged in without its vendor driver \
-                     installed.",
-                ),
+                t!("settings.usb_driver_title"),
+                Some(t!("settings.usb_driver_desc")),
                 bool_field(
                     "settings-detect-drivers",
-                    "Detect un-drivered USB adapters",
+                    t!("settings.usb_driver_toggle"),
                     !cur.disable_driver_detection,
                     cx,
                     SettingsView::set_detect_drivers,
@@ -2502,15 +2478,11 @@ impl SettingsView {
             ))
             .child(self.filtered_card(
                 s,
-                "Copy on Select",
-                Some(
-                    "PuTTY-style — copy the terminal selection to the \
-                     clipboard automatically when the mouse is released. \
-                     Avoids having to press \u{2318}/Ctrl+C for every snippet.",
-                ),
+                t!("settings.copy_on_select_title"),
+                Some(t!("settings.copy_on_select_desc")),
                 bool_field(
                     "settings-copy-on-select",
-                    "Copy terminal selection to clipboard automatically",
+                    t!("settings.copy_on_select_toggle"),
                     cur.copy_on_select,
                     cx,
                     SettingsView::set_copy_on_select,
@@ -2519,14 +2491,8 @@ impl SettingsView {
             .child(
                 self.filtered_card(
                     s,
-                    "Window State",
-                    Some(
-                        "Reopen Baudrun and Settings windows where you left \
-                     them. Turn off to land at the centered default \
-                     size each launch instead. The Reset buttons clear \
-                     the saved geometry and resize the matching live \
-                     windows immediately.",
-                    ),
+                    t!("settings.window_state_title"),
+                    Some(t!("settings.window_state_desc")),
                     // Two rows: the on/off toggle on top, then a pair of
                     // Reset buttons (Settings window vs main window) below.
                     // The two-button split lets the user fix just the
@@ -2537,7 +2503,7 @@ impl SettingsView {
                         .gap_2()
                         .child(bool_field(
                             "settings-restore-window-state",
-                            "Restore window size and position on launch",
+                            t!("settings.window_state_toggle"),
                             !cur.disable_window_state_restore,
                             cx,
                             SettingsView::set_restore_window_state,
@@ -2550,14 +2516,14 @@ impl SettingsView {
                                 .child(import_button(
                                     s,
                                     "reset-settings-window",
-                                    "Reset Settings window",
+                                    t!("settings.reset_settings_window"),
                                     cx,
                                     |this, window, cx| this.reset_settings_window(window, cx),
                                 ))
                                 .child(import_button(
                                     s,
                                     "reset-main-window",
-                                    "Reset main window",
+                                    t!("settings.reset_main_window"),
                                     cx,
                                     |this, window, cx| this.reset_main_window(window, cx),
                                 )),
@@ -2609,29 +2575,20 @@ impl SettingsView {
                                         div()
                                             .text_size(px(15.0))
                                             .text_color(rgba(s.fg_primary))
-                                            .child("Config Directory"),
+                                            .child(t!("settings.config_dir_title")),
                                     )
                                     .child(
                                         div()
                                             .text_size(px(12.0))
                                             .text_color(rgba(s.fg_secondary))
                                             .whitespace_normal()
-                                            .child(
-                                                "Where Baudrun stores profiles, themes, \
-                                                 skins, highlight packs, and \
-                                                 settings.json. Choose a different \
-                                                 location to share configs across \
-                                                 machines (Dropbox, iCloud Drive, \
-                                                 dotfile repo) or to test from a clean \
-                                                 directory. Takes effect on the next \
-                                                 launch.",
-                                            ),
+                                            .child(t!("settings.config_dir_desc")),
                                     ),
                             )
                             .child(import_button(
                                 s,
                                 "config-dir-reveal",
-                                "Reveal",
+                                t!("settings.reveal"),
                                 cx,
                                 |this, window, cx| this.reveal_config_dir(window, cx),
                             )),
@@ -2678,14 +2635,14 @@ impl SettingsView {
                             .child(div().flex_shrink_0().child(import_button(
                                 s,
                                 "config-dir-choose",
-                                "Choose\u{2026}",
+                                t!("settings.choose"),
                                 cx,
                                 |this, window, cx| this.choose_config_dir(window, cx),
                             )))
                             .child(div().flex_shrink_0().child(import_button(
                                 s,
                                 "config-dir-reset",
-                                "Reset",
+                                t!("settings.reset"),
                                 cx,
                                 |this, window, cx| this.reset_config_dir(window, cx),
                             ))),

--- a/src/terminal_view.rs
+++ b/src/terminal_view.rs
@@ -23,6 +23,7 @@
 //! (multiple grids per window, settings panes that don't need a
 //! parser, etc.).
 
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -1274,10 +1275,14 @@ impl TerminalView {
         // `gpui::div().child(...)` expects, so each row is a
         // standalone Div.
         type ClickHandler = Box<dyn Fn(&MouseUpEvent, &mut Window, &mut gpui::App) + 'static>;
-        let row = move |label: &'static str, enabled: bool, on_click: ClickHandler| -> AnyElement {
+        let row = move |id: &'static str,
+                        label: Cow<'static, str>,
+                        enabled: bool,
+                        on_click: ClickHandler|
+              -> AnyElement {
             let hover_bg = s.bg_hover;
             let d = div()
-                .id(SharedString::from(label))
+                .id(SharedString::from(id))
                 .px_3()
                 .py(px(6.0))
                 .text_color(rgba(s.fg_primary))
@@ -1301,6 +1306,7 @@ impl TerminalView {
             let entity = cx.entity();
             row(
                 "Copy",
+                t!("terminal.menu.copy"),
                 has_selection,
                 Box::new(move |_, _window, app| {
                     entity.update(app, |this, cx| {
@@ -1315,6 +1321,7 @@ impl TerminalView {
             let entity = cx.entity();
             row(
                 "Paste",
+                t!("terminal.menu.paste"),
                 true,
                 Box::new(move |_, window, app| {
                     entity.update(app, |this, cx| {
@@ -1329,6 +1336,7 @@ impl TerminalView {
             let entity = cx.entity();
             row(
                 "Select All",
+                t!("terminal.menu.select_all"),
                 true,
                 Box::new(move |_, _window, app| {
                     entity.update(app, |this, cx| {
@@ -1343,6 +1351,7 @@ impl TerminalView {
             let entity = cx.entity();
             row(
                 "Clear",
+                t!("terminal.menu.clear"),
                 true,
                 Box::new(move |_, _window, app| {
                     entity.update(app, |this, cx| {
@@ -1538,10 +1547,8 @@ impl TerminalView {
                 let bytes = bytes.clone();
                 alert
                     .confirm()
-                    .title("Paste multiple lines?")
-                    .description(format!(
-                        "About to paste {line_count} lines into the terminal."
-                    ))
+                    .title(t!("terminal.paste_confirm.title"))
+                    .description(t!("terminal.paste_confirm.body", count = line_count))
                     .on_ok(move |_, window, cx| {
                         let bytes = bytes.clone();
                         if let Some(this) = weak.upgrade() {


### PR DESCRIPTION
Closes the first phase of #72 (i18n support, requested by @taotieren).

## What this does

Adds the infrastructure to run Baudrun's UI in a non-English locale, plus a **Settings → Appearance → Language** picker to choose one. "Auto" follows the OS.

**Simplified Chinese (简体中文)** is the first non-English target — the issue reporter writes it, and gpui-component already ships matching `zh-CN` widget strings.

## Scope boundary (important)

This phase installs the locale **globally** but does **not** yet translate Baudrun's own ~180 strings. So after switching to 简体中文 today, you'll see gpui-component's shared chrome (dropdown search box, dialogs, calendar) flip to Chinese, while Baudrun's own labels stay English until **Phase A.2** extracts them. Terminal output is never translated. This is the deliberate A.1/A.2 split documented in `TODO.md`.

## How it works

- **`src/i18n.rs`** — `SUPPORTED` list (`en`, `zh-CN`) + a resolver with precedence: `Settings.locale` → OS locale → English.
  - The OS matcher is **Chinese-aware**: it keeps the script/region subtags instead of stripping to a bare language tag, so `zh` / `zh-Hans-CN` / `zh-CN` / `zh-SG` all resolve to `zh-CN`. A bare-tag strip (what the sibling PortFinder app does) would miss the region-qualified code and fall through to English. Traditional locales (`zh-Hant`/`TW`/`HK`/`MO`) route to English until a Traditional catalog ships, rather than silently serving Simplified. Unit-tested.
- **`Settings.locale`** field (`""` = follow OS).
- **`i18n::init`** at boot installs the resolved locale via `gpui_component::set_locale` before the first window builds.
- **`AppView::apply_locale`**, called from `apply_settings`, re-installs on every settings change. Because `apply_settings` fires from the SettingsBus subscription in **every** window, a language change in one window re-renders all of them — the cross-window path skin/font already use, **not** a local `cx.notify()` (which would leave other windows stale — the same bug class the recent ProfilesBus work fixed).
- **Language picker** in the Appearance tab (endonym-labelled options), following the existing Appearance-dropdown pattern.
- **`sys-locale`** dependency for OS detection.

## Also included (unrelated, flagged)

`b8f8524` bumps **crossbeam-epoch 0.9.18 → 0.9.20** for **RUSTSEC-2026-0204** (null-pointer deref in a `fmt::Display` impl), published after v0.14.0 shipped. It's a transitive dep and was failing `cargo deny check` on `main` as of today — this PR lands the fix. Separate commit so it's cherry-pickable independently of the i18n feature.

## Verification

- `cargo test` — 5 new `i18n` resolver tests (Simplified/Traditional/OS/override cases) pass; full suite green.
- `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo deny check` — all clean.
- Boot log confirms `i18n::init` resolves correctly (`en` from an English OS with empty settings).
- **Not yet done interactively:** a live screenshot of the zh-CN switch — worth a manual check that the widget chrome flips as expected.

## Follow-ups (tracked in TODO.md)

- **Phase A.2** — extract Baudrun's ~180 strings to `locales/*.yml` (YAML, not the originally-planned TOML) + wrap in `t!()`. Includes the captured-label caveat: `Select` option titles and tab labels built in `::new` need rebuilding on locale change.
- **Phase B** — translator PRs add `locales/<lang>.yml` + one `SUPPORTED` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)